### PR TITLE
fix(blog): keep header links inline on mobile

### DIFF
--- a/apps/blog/blog/components/SiteLayout.js
+++ b/apps/blog/blog/components/SiteLayout.js
@@ -74,7 +74,7 @@ export function SiteNavHeader() {
   return (
     <AppBar position="static" data-testid="Nav-AppBar" sx={{backgroundColor: 'white' }}>
       <Toolbar disableGutters variant="dense" data-testid="Nav-Toolbar" >
-        <ResponsiveRow data-testid="Nav-ResponsiveRow">
+        <ResponsiveRow data-testid="Nav-ResponsiveRow" sx={{ flexDirection: 'row' }}>
           <HeaderNavLink href="/" data-testid="Nav-Link-Home" sx={{marginLeft: 0}}><HomeIcon /></HeaderNavLink>
           <HeaderNavLink href="/index1.html" data-testid="Nav-Link-Archive">Archive</HeaderNavLink>
           <HeaderNavLink href="/about.html" data-testid="Nav-Link-About">About</HeaderNavLink>


### PR DESCRIPTION
## Summary
- ensure blog navigation links remain on one line for mobile

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: `react/no-unescaped-entities` etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a664d695188332b2173bd90dcd11d2