### PR TITLE
robot-battle: v0.13.0 — level scaling, end-game boss, multi-buy upgrades

### DIFF
--- a/apps/games/robot-battle/package.json
+++ b/apps/games/robot-battle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kylep/robot-battle",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/games/robot-battle/src/engine/battle.ts
+++ b/apps/games/robot-battle/src/engine/battle.ts
@@ -20,6 +20,7 @@ import {
   getEffectiveHands,
   getEffectiveMaxEnergy,
   getEffectiveMaxHealth,
+  getLevelStatBonus,
   getRestEnergyBonus,
   hasItem,
   isAlive,
@@ -78,7 +79,10 @@ export function calculateDamage(
 ): number {
   const attackPercent = getEffectiveAttack(attacker.robot) + attacker.tempAttack;
   const defence = battleDefence(defender);
-  const modified = weapon.damage * (1 + attackPercent / 100);
+  // Flat per-level damage bonus (cancels cleanly with the defender's flat
+  // per-level defence bonus at same level).
+  const levelDamageBonus = getLevelStatBonus(attacker.robot);
+  const modified = weapon.damage * (1 + attackPercent / 100) + levelDamageBonus;
   return Math.max(0, Math.floor(modified) - defence);
 }
 
@@ -241,9 +245,11 @@ export function useConsumable(
       if (r.random() < dodgeChance) {
         effects.push(`enemy dodged ${consumable.name}!`);
       } else {
-        // Defence reduces consumable damage
+        // Defence reduces consumable damage; flat level bonus adds to it
+        // so same-level throws still net the same damage as before scaling.
         const defence = battleDefence(defender);
-        let dmg = Math.max(0, consumable.damage - defence);
+        const levelDamageBonus = getLevelStatBonus(attacker.robot);
+        let dmg = Math.max(0, consumable.damage + levelDamageBonus - defence);
         if (defender.damageBlock > 0) {
           const blocked = Math.min(dmg, defender.damageBlock);
           defender.damageBlock -= blocked;

--- a/apps/games/robot-battle/src/engine/boss.ts
+++ b/apps/games/robot-battle/src/engine/boss.ts
@@ -1,0 +1,231 @@
+/** End-game boss: randomly generated opponent that appears after winning a round. */
+
+import type { AssetRegistry } from "./data";
+import type { EndGameBossSpec, Enemy, Item, Robot, Weapon, Gear, Consumable } from "./types";
+import {
+  listRepeatableUpgrades,
+  getRepeatableUpgradeCost,
+  getUpgrade,
+  applyAllUpgrades,
+} from "./upgrades";
+
+const BOSS_FIRST_NAMES = [
+  "Poopy",
+  "Stinky",
+  "Sir Booger",
+  "Captain Underpants",
+  "Princess Puddle",
+  "Mr. Fart",
+  "Wedgie",
+  "Tooty",
+  "Snotrocket",
+  "Burpy",
+  "Gassy",
+  "Drooly",
+  "Smelly",
+  "Pickle",
+  "Cheese Goblin",
+  "Uncle Meatball",
+  "Chonky",
+  "Slimey",
+  "Buttbot",
+  "Diaper Dan",
+  "Nugget",
+  "Waffle",
+  "Sock Monster",
+  "Bogey",
+  "Gurgles",
+];
+
+const BOSS_TITLES = [
+  "the Destroyer",
+  "the Magnificent",
+  "the Unflushable",
+  "the Belcher",
+  "the Thunder-Butt",
+  "the Stinkmaster",
+  "the Cookie Thief",
+  "the Pants-Wetter",
+  "the Bonkers",
+  "the Sticky",
+  "the Rotten",
+  "the Dreaded",
+  "the Toilet Menace",
+  "the Booger King",
+  "the Fart Lord",
+  "the Slobber",
+  "the Unwashed",
+  "the Tuba Player",
+  "the Wiggly",
+  "the Waffle Wizard",
+];
+
+function randomBossName(): string {
+  const first = BOSS_FIRST_NAMES[Math.floor(Math.random() * BOSS_FIRST_NAMES.length)];
+  const title = BOSS_TITLES[Math.floor(Math.random() * BOSS_TITLES.length)];
+  return `${first} ${title}`;
+}
+
+function pickBestWeapons(registry: AssetRegistry, count: number): string[] {
+  const weapons = Array.from(registry.weapons.values())
+    .filter((w) => !w.requirements || w.requirements.length === 0)
+    .sort((a, b) => b.damage - a.damage);
+  return weapons.slice(0, count).map((w) => w.name);
+}
+
+function pickBestGear(registry: AssetRegistry, count: number): string[] {
+  // Sort by level desc (proxy for strength), pick top N non-stackable
+  const gear = Array.from(registry.gear.values())
+    .filter((g) => !g.stackable)
+    .sort((a, b) => b.level - a.level || b.moneyCost - a.moneyCost);
+  return gear.slice(0, count).map((g) => g.name);
+}
+
+function pickBestConsumables(registry: AssetRegistry): string[] {
+  // Give a spread of top-tier consumables
+  const cons = Array.from(registry.consumables.values())
+    .sort((a, b) => b.level - a.level || b.moneyCost - a.moneyCost);
+  const names: string[] = [];
+  for (const c of cons.slice(0, 5)) {
+    // 2 copies of each top consumable, bounded by maxStack
+    const copies = Math.min(2, c.maxStack > 0 ? c.maxStack : 2);
+    for (let i = 0; i < copies; i++) names.push(c.name);
+  }
+  return names;
+}
+
+function calculatePlayerWorth(player: Robot): number {
+  const upgradeCost = player.upgrades.reduce((sum, id) => {
+    const def = getUpgrade(id);
+    return sum + (def?.cost ?? 0);
+  }, 0);
+  let repUpgradeCost = 0;
+  const repDefs = listRepeatableUpgrades();
+  for (const [id, level] of Object.entries(player.repeatableUpgrades)) {
+    const def = repDefs.find((r) => r.id === id);
+    if (!def) continue;
+    for (let i = 0; i < level; i++) {
+      repUpgradeCost += getRepeatableUpgradeCost(def, i);
+    }
+  }
+  return player.money + player.bank + upgradeCost + repUpgradeCost;
+}
+
+/** Spend the given budget on repeatable upgrades, rotating through available types. */
+function spendBudgetOnRepeatables(budget: number): Record<string, number> {
+  const levels: Record<string, number> = {};
+  const defs = listRepeatableUpgrades();
+  let remaining = budget;
+  let progress = true;
+  while (remaining > 0 && progress) {
+    progress = false;
+    for (const def of defs) {
+      const currentLevel = levels[def.id] ?? 0;
+      const cost = getRepeatableUpgradeCost(def, currentLevel);
+      if (cost <= remaining) {
+        levels[def.id] = currentLevel + 1;
+        remaining -= cost;
+        progress = true;
+      }
+    }
+  }
+  return levels;
+}
+
+/** Generate a random end-game boss stronger than the given player. */
+export function generateEndGameBossSpec(registry: AssetRegistry, player: Robot): EndGameBossSpec {
+  const budget = Math.floor(calculatePlayerWorth(player) * 1.25);
+  const repeatableUpgrades = spendBudgetOnRepeatables(budget);
+
+  // Total hands needed to wield multiple weapons — boss gets "sixth-arm" effectively
+  const weapons = pickBestWeapons(registry, 3);
+  const gear = pickBestGear(registry, 4);
+  const consumables = pickBestConsumables(registry);
+
+  return {
+    name: randomBossName(),
+    level: Math.max(player.level + 1, 1),
+    weapons,
+    gear,
+    consumables,
+    repeatableUpgrades,
+  };
+}
+
+/** Build a Robot from a boss spec, tied to the player's NG+ level for scaling. */
+export function createBossRobot(
+  registry: AssetRegistry,
+  spec: EndGameBossSpec,
+  playerNewGamePlusLevel: number,
+): Robot {
+  const stats = registry.defaultRobotStats;
+  const robot: Robot = {
+    name: spec.name,
+    health: stats.health,
+    maxHealth: stats.maxHealth,
+    energy: stats.energy,
+    maxEnergy: stats.maxEnergy,
+    defence: stats.defence,
+    attack: stats.attack,
+    hands: 6, // boss has 6 arms so it can dual-wield heavy gear
+    dodge: stats.dodge,
+    accuracy: 0,
+    level: spec.level,
+    exp: 0,
+    money: 0,
+    bank: 0,
+    wins: 0,
+    fights: 0,
+    inventorySize: 99,
+    inventory: [],
+    upgrades: [],
+    repeatableUpgrades: { ...spec.repeatableUpgrades },
+    settings: {
+      mode: "oliver",
+      oliverChallenge: false,
+      autoDeposit: false,
+      restockConsumables: false,
+    },
+    defeatedEnemies: [],
+    challengeDefeatedEnemies: [],
+    cheatsUsed: false,
+    godMode: false,
+    newGamePlusLevel: playerNewGamePlusLevel,
+    titanDefeated: false,
+    endGameBoss: null,
+  };
+
+  for (const name of spec.weapons) {
+    const w = registry.weapons.get(name);
+    if (w) robot.inventory.push({ ...w } as Weapon);
+  }
+  for (const name of spec.gear) {
+    const g = registry.gear.get(name);
+    if (g) robot.inventory.push({ ...g } as Gear);
+  }
+  for (const name of spec.consumables) {
+    const c = registry.consumables.get(name);
+    if (c) robot.inventory.push({ ...c } as Consumable);
+  }
+
+  applyAllUpgrades(robot);
+  return robot;
+}
+
+/** Build an Enemy record suitable for the battle / detail UI from a boss spec. */
+export function bossAsEnemy(spec: EndGameBossSpec): Enemy {
+  return {
+    name: spec.name,
+    level: spec.level,
+    weapons: spec.weapons,
+    gear: spec.gear,
+    consumables: spec.consumables,
+    upgrades: [],
+    reward: 50000,
+    expReward: 100,
+    description: "A terrifying opponent unlike any other.",
+    appearance: "It glares at you with unnatural menace.",
+    backstory: "Born from the echoes of your own victories, this foe is your reckoning.",
+    challengeName: "",
+  };
+}

--- a/apps/games/robot-battle/src/engine/data.ts
+++ b/apps/games/robot-battle/src/engine/data.ts
@@ -198,6 +198,7 @@ export function loadAssets(): AssetRegistry {
         godMode: false,
         newGamePlusLevel: 0,
         titanDefeated: false,
+        endGameBoss: null,
       };
 
       for (const wName of enemy.weapons) {

--- a/apps/games/robot-battle/src/engine/robot.ts
+++ b/apps/games/robot-battle/src/engine/robot.ts
@@ -21,20 +21,31 @@ export function getConsumables(robot: Robot): Consumable[] {
   return robot.inventory.filter((i): i is Consumable => i.itemType === "consumable");
 }
 
+/** Per-level stat bonus for accuracy/dodge/defence/attack.
+ *  Base is +1 per level, plus +1 per New Game+ round. */
+export function getLevelStatBonus(robot: Robot): number {
+  return robot.level * (1 + (robot.newGamePlusLevel ?? 0));
+}
+
+/** Per-level HP bonus. Base is +2 per level, plus +1 per New Game+ round. */
+export function getLevelHealthBonus(robot: Robot): number {
+  return robot.level * (2 + (robot.newGamePlusLevel ?? 0));
+}
+
 export function getEffectiveHands(robot: Robot): number {
   return robot.hands + getGear(robot).reduce((s, g) => s + g.handsBonus, 0);
 }
 
 export function getEffectiveDodge(robot: Robot): number {
-  return robot.dodge + getGear(robot).reduce((s, g) => s + g.dodgeBonus, 0);
+  return robot.dodge + getLevelStatBonus(robot) + getGear(robot).reduce((s, g) => s + g.dodgeBonus, 0);
 }
 
 export function getEffectiveDefence(robot: Robot): number {
-  return robot.defence + getGear(robot).reduce((s, g) => s + g.defenceBonus, 0);
+  return robot.defence + getLevelStatBonus(robot) + getGear(robot).reduce((s, g) => s + g.defenceBonus, 0);
 }
 
 export function getEffectiveMaxHealth(robot: Robot): number {
-  return robot.maxHealth + robot.level * 2 + getGear(robot).reduce((s, g) => s + g.healthBonus, 0);
+  return robot.maxHealth + getLevelHealthBonus(robot) + getGear(robot).reduce((s, g) => s + g.healthBonus, 0);
 }
 
 export function getEffectiveMaxEnergy(robot: Robot): number {
@@ -42,7 +53,7 @@ export function getEffectiveMaxEnergy(robot: Robot): number {
 }
 
 export function getEffectiveAttack(robot: Robot): number {
-  return robot.attack + getGear(robot).reduce((s, g) => s + g.attackBonus, 0);
+  return robot.attack + getLevelStatBonus(robot) + getGear(robot).reduce((s, g) => s + g.attackBonus, 0);
 }
 
 export function getRestEnergyBonus(robot: Robot): number {
@@ -50,7 +61,7 @@ export function getRestEnergyBonus(robot: Robot): number {
 }
 
 export function getEffectiveAccuracy(robot: Robot): number {
-  return robot.accuracy + getGear(robot).reduce((s, g) => s + g.accuracyBonus, 0);
+  return robot.accuracy + getLevelStatBonus(robot) + getGear(robot).reduce((s, g) => s + g.accuracyBonus, 0);
 }
 
 export function getMoneyBonusPercent(robot: Robot): number {

--- a/apps/games/robot-battle/src/engine/robot.ts
+++ b/apps/games/robot-battle/src/engine/robot.ts
@@ -53,7 +53,9 @@ export function getEffectiveMaxEnergy(robot: Robot): number {
 }
 
 export function getEffectiveAttack(robot: Robot): number {
-  return robot.attack + getLevelStatBonus(robot) + getGear(robot).reduce((s, g) => s + g.attackBonus, 0);
+  // Attack is a % multiplier stat. Level scaling contributes flat damage
+  // per attack instead (see calculateDamage), so it's not folded in here.
+  return robot.attack + getGear(robot).reduce((s, g) => s + g.attackBonus, 0);
 }
 
 export function getRestEnergyBonus(robot: Robot): number {

--- a/apps/games/robot-battle/src/engine/save.ts
+++ b/apps/games/robot-battle/src/engine/save.ts
@@ -54,6 +54,7 @@ function parseSave(raw: string | null): SaveData | null {
     if (data.player.godMode === undefined) data.player.godMode = false;
     if (data.player.newGamePlusLevel === undefined) data.player.newGamePlusLevel = 0;
     if (data.player.titanDefeated === undefined) data.player.titanDefeated = false;
+    if (data.player.endGameBoss === undefined) data.player.endGameBoss = null;
     // Migrate arm gear items to arm upgrades
     const armGearNames = ["Third Arm", "Fourth Arm", "Fifth Arm", "Sixth Arm"];
     const armUpgradeIds = ["third-arm", "fourth-arm", "fifth-arm", "sixth-arm"];

--- a/apps/games/robot-battle/src/engine/state.ts
+++ b/apps/games/robot-battle/src/engine/state.ts
@@ -43,6 +43,7 @@ export function createPlayer(state: GameState, name: string): Robot {
     godMode: false,
     newGamePlusLevel: 0,
     titanDefeated: false,
+    endGameBoss: null,
   };
   // Give player a free starter Stick
   const stick = state.registry.getItem("Stick");

--- a/apps/games/robot-battle/src/engine/types.ts
+++ b/apps/games/robot-battle/src/engine/types.ts
@@ -78,6 +78,16 @@ export interface Robot {
   godMode: boolean;
   newGamePlusLevel: number;
   titanDefeated: boolean;
+  endGameBoss: EndGameBossSpec | null;
+}
+
+export interface EndGameBossSpec {
+  name: string;
+  level: number;
+  weapons: string[];
+  gear: string[];
+  consumables: string[];
+  repeatableUpgrades: Record<string, number>;
 }
 
 export interface Enemy {

--- a/apps/games/robot-battle/src/engine/upgrades.ts
+++ b/apps/games/robot-battle/src/engine/upgrades.ts
@@ -108,17 +108,47 @@ export interface RepeatableUpgradeDef {
 const REPEATABLE_UPGRADES: RepeatableUpgradeDef[] = [
   { id: "rep-hp", name: "+5 Max HP", baseCost: 2000, costPerLevel: 1000, description: "+5 Max HP per level" },
   { id: "rep-damage", name: "+1 Attack", baseCost: 3000, costPerLevel: 1500, description: "+1% Attack per level" },
+  { id: "rep-damage-plus", name: "+3 Attack II", baseCost: 30000, costPerLevel: 15000, description: "+3% Attack per level (premium)" },
   { id: "rep-defence", name: "+1 Defence", baseCost: 2500, costPerLevel: 1200, description: "+1 Defence per level" },
   { id: "rep-accuracy", name: "+2 Accuracy", baseCost: 2000, costPerLevel: 1000, description: "+2 Accuracy per level" },
   { id: "rep-dodge", name: "+1 Dodge", baseCost: 2000, costPerLevel: 1000, description: "+1 Dodge per level" },
+  { id: "rep-energy", name: "+5 Max Energy", baseCost: 2500, costPerLevel: 1200, description: "+5 Max Energy per level" },
 ];
 
 export function listRepeatableUpgrades(): RepeatableUpgradeDef[] {
   return REPEATABLE_UPGRADES;
 }
 
+/** Cost scales with flat per-level increase AND +2% compounding per level. */
 export function getRepeatableUpgradeCost(def: RepeatableUpgradeDef, currentLevel: number): number {
-  return def.baseCost + def.costPerLevel * currentLevel;
+  const linear = def.baseCost + def.costPerLevel * currentLevel;
+  const compounded = linear * Math.pow(1.02, currentLevel);
+  return Math.floor(compounded);
+}
+
+/** Compute how many levels of this upgrade a player can afford right now,
+ *  and the total cost for that many levels. */
+export function getAffordableRepeatableLevels(
+  player: Robot,
+  def: RepeatableUpgradeDef,
+): { maxLevels: number; totalCost: number } {
+  const startLevel = player.repeatableUpgrades[def.id] ?? 0;
+  if (player.settings.mode === "sandbox") {
+    // Sandbox: allow "buy 1" only (no money to spend)
+    return { maxLevels: 1, totalCost: 0 };
+  }
+  let budget = player.money;
+  let levels = 0;
+  let totalCost = 0;
+  while (true) {
+    const cost = getRepeatableUpgradeCost(def, startLevel + levels);
+    if (cost > budget) break;
+    budget -= cost;
+    totalCost += cost;
+    levels++;
+    if (levels > 9999) break; // safety
+  }
+  return { maxLevels: levels, totalCost };
 }
 
 export function allNormalUpgradesPurchased(player: Robot): boolean {
@@ -148,12 +178,34 @@ export function buyRepeatableUpgrade(player: Robot, def: RepeatableUpgradeDef): 
   applyRepeatableEffect(player, def.id, 1);
 }
 
+/** Buy multiple levels of a repeatable upgrade at once. Returns levels actually purchased. */
+export function buyRepeatableUpgradeMulti(
+  player: Robot,
+  def: RepeatableUpgradeDef,
+  desired: number,
+): number {
+  if (desired <= 0) return 0;
+  let bought = 0;
+  for (let i = 0; i < desired; i++) {
+    const level = player.repeatableUpgrades[def.id] ?? 0;
+    const cost = getRepeatableUpgradeCost(def, level);
+    if (player.settings.mode !== "sandbox" && player.money < cost) break;
+    if (player.settings.mode !== "sandbox") player.money -= cost;
+    player.repeatableUpgrades[def.id] = level + 1;
+    applyRepeatableEffect(player, def.id, 1);
+    bought++;
+  }
+  return bought;
+}
+
 function applyRepeatableEffect(player: Robot, id: string, levels: number): void {
   if (id === "rep-hp") player.maxHealth += 5 * levels;
   if (id === "rep-damage") player.attack += 1 * levels;
+  if (id === "rep-damage-plus") player.attack += 3 * levels;
   if (id === "rep-defence") player.defence += 1 * levels;
   if (id === "rep-accuracy") player.accuracy += 2 * levels;
   if (id === "rep-dodge") player.dodge += 1 * levels;
+  if (id === "rep-energy") player.maxEnergy += 5 * levels;
 }
 
 function applyAllRepeatableUpgrades(player: Robot): void {

--- a/apps/games/robot-battle/src/ui/screens/battle.ts
+++ b/apps/games/robot-battle/src/ui/screens/battle.ts
@@ -3,6 +3,7 @@
 import type { Terminal, Choice } from "../terminal";
 import type { GameState } from "../../engine/state";
 import type { BattleState, Enemy, Rng, Weapon } from "../../engine/types";
+import { bossAsEnemy, createBossRobot, generateEndGameBossSpec } from "../../engine/boss";
 import {
   createBattle,
   endTurn,
@@ -113,12 +114,29 @@ export async function battleScreen(
   storage?: SaveStorage,
 ): Promise<"continue" | "fight-again" | "shop"> {
   const player = state.player!;
-  const enemyDef = state.registry.enemies.get(enemyName)!;
-  const enemyRobot = state.registry.createEnemyRobot(enemyName);
+  // Boss path — end-game boss is generated dynamically, not in registry
+  const isBoss = player.endGameBoss !== null && enemyName === player.endGameBoss.name;
+  let enemyDef: Enemy;
+  let enemyRobot: ReturnType<typeof state.registry.createEnemyRobot>;
+  if (isBoss) {
+    enemyDef = bossAsEnemy(player.endGameBoss!);
+    enemyRobot = createBossRobot(state.registry, player.endGameBoss!, player.newGamePlusLevel);
+  } else {
+    const regEnemy = state.registry.enemies.get(enemyName);
+    if (!regEnemy) {
+      terminal.print("Error: enemy not found!", "t-red");
+      return "continue";
+    }
+    enemyDef = regEnemy;
+    enemyRobot = state.registry.createEnemyRobot(enemyName);
+  }
   if (!enemyRobot) {
     terminal.print("Error creating enemy!", "t-red");
     return "continue";
   }
+
+  // Scale enemy level bonuses to the player's NG+ round
+  enemyRobot.newGamePlusLevel = player.newGamePlusLevel;
 
   // Oliver's EXTRA CHALLENGE: enemies get 3x HP per level
   const isChallenge = player.settings.oliverChallenge;
@@ -127,8 +145,16 @@ export async function battleScreen(
   }
 
   // Use challenge name during combat if available
-  const displayName = isChallenge && enemyDef.challengeName ? enemyDef.challengeName : enemyName;
-  const nameClass = isChallenge && enemyDef.challengeName ? "t-purple" : "t-magenta";
+  const displayName = isBoss
+    ? enemyName
+    : isChallenge && enemyDef.challengeName
+    ? enemyDef.challengeName
+    : enemyName;
+  const nameClass = isBoss
+    ? "t-red"
+    : isChallenge && enemyDef.challengeName
+    ? "t-purple"
+    : "t-magenta";
   enemyRobot.name = displayName;
 
   const fightNumber = player.fights + 1;
@@ -216,7 +242,8 @@ export async function battleScreen(
     const restocked = restockConsumables(state, battle.player.consumablesUsed);
 
     // Track defeated enemies (not in sandbox — badges are a normal-mode reward)
-    if (player.settings.mode !== "sandbox") {
+    // Boss doesn't count toward defeated-enemies totals
+    if (player.settings.mode !== "sandbox" && !isBoss) {
       if (!player.defeatedEnemies.includes(enemyName)) {
         player.defeatedEnemies.push(enemyName);
       }
@@ -243,6 +270,8 @@ export async function battleScreen(
           cheatsUsed: player.cheatsUsed,
         });
       }
+      // Generate an end-game boss for this run — replaces any prior boss
+      player.endGameBoss = generateEndGameBossSpec(state.registry, player);
       terminal.clear();
       terminal.printHTML(`
         <div class="title-center" style="min-height:0;margin:24px 0">

--- a/apps/games/robot-battle/src/ui/screens/menu.ts
+++ b/apps/games/robot-battle/src/ui/screens/menu.ts
@@ -18,6 +18,7 @@ import {
 } from "../../engine/robot";
 import { createPlayer, getXpToLevel } from "../../engine/state";
 import { applyAllUpgrades } from "../../engine/upgrades";
+import { bossAsEnemy, createBossRobot, generateEndGameBossSpec } from "../../engine/boss";
 import { shopScreen } from "./shop";
 import { upgradesScreen } from "./upgrades";
 import { bankScreen } from "./bank";
@@ -109,6 +110,10 @@ export async function mainMenu(
         newPlayer.settings = oldPlayer.settings;
         newPlayer.repeatableUpgrades = { ...oldPlayer.repeatableUpgrades };
         applyAllUpgrades(newPlayer);
+        // Regenerate end-game boss for the new run if one existed (fresh random name + loadout)
+        if (oldPlayer.endGameBoss) {
+          newPlayer.endGameBoss = generateEndGameBossSpec(state.registry, newPlayer);
+        }
         save?.();
       }
     }
@@ -240,6 +245,15 @@ async function cheatCodeScreen(
       const fact = factsData.cheat_godmode[Math.floor(Math.random() * factsData.cheat_godmode.length)];
       terminal.printHTML(`<div class="panel" style="padding:8px 12px;margin-top:8px"><span class="t-cyan t-bold">Divine Knowledge:</span> <span class="t-dim">${esc(fact)}</span></div>`);
       await terminal.promptContinue(0);
+    } else if (trimmed === "treasure") {
+      player.cheatsUsed = true;
+      const amount = 1_000_000;
+      player.money += amount;
+      terminal.clear();
+      terminal.printHTML(`<div class="t-yellow t-bold" style="font-size:20px;margin:16px 0">✦ TREASURE! ✦</div>`);
+      terminal.printHTML(`<div class="t-green t-bold" style="font-size:18px">+$${amount.toLocaleString()} added to your wallet!</div>`);
+      terminal.printHTML(`<div class="panel" style="padding:8px 12px;margin-top:8px"><span class="t-cyan t-bold">Treasure tip:</span> <span class="t-dim">Spending money is much more fun than saving it.</span></div>`);
+      await terminal.promptContinue(0);
     } else if (trimmed === "nuclear fission") {
       player.cheatsUsed = true;
       terminal.clear();
@@ -344,15 +358,30 @@ async function fightMenu(terminal: Terminal, state: GameState, sound?: SoundPlay
         labelClass: challengeOn && enemy.challengeName ? "t-purple" : undefined,
       });
     }
+    // End-game boss — only shown once every other enemy has been defeated
+    const allDefeated = player.defeatedEnemies.length >= enemies.length;
+    if (allDefeated && player.endGameBoss) {
+      const boss = player.endGameBoss;
+      choices.push({
+        label: `${boss.name} (Lv.${boss.level})`,
+        value: `__boss__${boss.name}`,
+        subtitle: `[End-Game Boss] Defeat the reckoning.`,
+        labelClass: "t-red",
+      });
+    }
     choices.push({ label: "Back", value: "back", subtitle: "Return to menu" });
 
     const choice = await terminal.promptChoice("", choices, "grid");
 
     if (choice === "back") return;
 
-    const shouldFight = await enemyDetailScreen(terminal, state, choice);
+    let targetEnemyName = choice;
+    if (choice.startsWith("__boss__")) {
+      targetEnemyName = choice.slice("__boss__".length);
+    }
+    const shouldFight = await enemyDetailScreen(terminal, state, targetEnemyName);
     if (shouldFight) {
-      let opponent = choice;
+      let opponent = targetEnemyName;
       while (true) {
         const result = await battleScreen(terminal, state, opponent, sound, storage);
         if (result === "shop") {
@@ -371,13 +400,21 @@ async function enemyDetailScreen(
   enemyName: string,
 ): Promise<boolean> {
   const player = state.player!;
-  const enemyDef = state.registry.enemies.get(enemyName)!;
+  const isBoss = player.endGameBoss !== null && enemyName === player.endGameBoss.name;
+  const enemyDef: Enemy = isBoss
+    ? bossAsEnemy(player.endGameBoss!)
+    : state.registry.enemies.get(enemyName)!;
 
   while (true) {
-    const bot = state.registry.createEnemyRobot(enemyName);
+    const bot = isBoss
+      ? createBossRobot(state.registry, player.endGameBoss!, player.newGamePlusLevel)
+      : state.registry.createEnemyRobot(enemyName);
     if (!bot) return false;
 
-    if (player.settings.oliverChallenge) {
+    // Scale enemy level bonuses to player NG+ for preview
+    bot.newGamePlusLevel = player.newGamePlusLevel;
+
+    if (player.settings.oliverChallenge && !isBoss) {
       bot.maxHealth += bot.level * 4;
     }
 
@@ -400,8 +437,16 @@ async function enemyDetailScreen(
 
     const challengeLabel = player.settings.oliverChallenge ? "Challenge: ON" : "Challenge: OFF";
     const isChallenge = player.settings.oliverChallenge;
-    const displayName = isChallenge && enemyDef.challengeName ? enemyDef.challengeName : enemyName;
-    const nameClass = isChallenge && enemyDef.challengeName ? "t-purple" : "t-yellow";
+    const displayName = isBoss
+      ? enemyName
+      : isChallenge && enemyDef.challengeName
+      ? enemyDef.challengeName
+      : enemyName;
+    const nameClass = isBoss
+      ? "t-red"
+      : isChallenge && enemyDef.challengeName
+      ? "t-purple"
+      : "t-yellow";
 
     terminal.clear();
     terminal.printHTML(`
@@ -441,6 +486,20 @@ function esc(s: string): string {
 }
 
 const CHANGELOG: { version: string; date: string; notes: string[] }[] = [
+  {
+    version: "0.13.0", date: "2026-04-10", notes: [
+      "Level scaling: every level grants +1 Accuracy, +1 Dodge, +1 Defence, +1 Attack, +2 HP",
+      "New Game + bonus: +1 to every level bonus (incl. HP) per NG+ round — applies to enemies too",
+      "Repeatable upgrades: new '+5 Max Energy' repeatable",
+      "Repeatable upgrades: new '+3 Attack II' premium repeatable at 10× cost",
+      "Repeatable upgrades now buy in bulk — choose the quantity, up to what you can afford",
+      "Repeatable upgrade costs: added +2% compounding per level on top of the flat increase",
+      "End-Game Boss: on every 100% Challenge completion, a random boss is generated — sum of your net worth × 1.25 in repeatables, best items, red name, goofy random names",
+      "Boss regenerates on New Game + (fresh name, fresh loadout)",
+      "Boss only appears in the Fight menu once every other enemy is defeated",
+      "New cheat code: 'treasure' grants +$1,000,000",
+    ],
+  },
   {
     version: "0.12.0", date: "2026-04-08", notes: [
       "Victory facts: random 'Did you know?' after every win (154 facts)",

--- a/apps/games/robot-battle/src/ui/screens/shop.ts
+++ b/apps/games/robot-battle/src/ui/screens/shop.ts
@@ -369,12 +369,15 @@ async function renderDetailsTab(terminal: Terminal, state: GameState): Promise<s
   const gear = getGear(player);
 
   // Base stats (from level-ups, upgrades, and base values)
-  const baseMaxHp = player.maxHealth + player.level * 2;
+  const ngp = player.newGamePlusLevel ?? 0;
+  const levelStatBonus = player.level * (1 + ngp);
+  const levelHpBonus = player.level * (2 + ngp);
+  const baseMaxHp = player.maxHealth + levelHpBonus;
   const baseMaxEn = player.maxEnergy;
-  const baseAtk = player.attack;
-  const baseDef = player.defence;
-  const baseDodge = player.dodge;
-  const baseAcc = player.accuracy;
+  const baseAtk = player.attack + levelStatBonus;
+  const baseDef = player.defence + levelStatBonus;
+  const baseDodge = player.dodge + levelStatBonus;
+  const baseAcc = player.accuracy + levelStatBonus;
   const baseHands = player.hands;
 
   // Gear bonuses

--- a/apps/games/robot-battle/src/ui/screens/shop.ts
+++ b/apps/games/robot-battle/src/ui/screens/shop.ts
@@ -374,7 +374,7 @@ async function renderDetailsTab(terminal: Terminal, state: GameState): Promise<s
   const levelHpBonus = player.level * (2 + ngp);
   const baseMaxHp = player.maxHealth + levelHpBonus;
   const baseMaxEn = player.maxEnergy;
-  const baseAtk = player.attack + levelStatBonus;
+  const baseAtk = player.attack; // attack % — level bonus is flat dmg, shown separately
   const baseDef = player.defence + levelStatBonus;
   const baseDodge = player.dodge + levelStatBonus;
   const baseAcc = player.accuracy + levelStatBonus;
@@ -411,6 +411,9 @@ async function renderDetailsTab(terminal: Terminal, state: GameState): Promise<s
   html += statLine("Max HP", baseMaxHp, gearHp, effHp);
   html += statLine("Max Energy", baseMaxEn, gearEn, effEn);
   html += statLine("Attack", baseAtk, gearAtk, effAtk, "%");
+  if (levelStatBonus > 0) {
+    html += `<div><span class="t-dim" style="display:inline-block;width:90px">Lv Dmg Bonus</span> <span class="t-yellow t-bold">+${levelStatBonus}</span> <span class="t-dim">(flat per attack)</span></div>`;
+  }
   html += statLine("Defence", baseDef, gearDef, effDef);
   html += statLine("Dodge", baseDodge, gearDodge, effDodge);
   html += statLine("Accuracy", baseAcc, gearAcc, effAcc);

--- a/apps/games/robot-battle/src/ui/screens/upgrades.ts
+++ b/apps/games/robot-battle/src/ui/screens/upgrades.ts
@@ -10,7 +10,9 @@ import {
   listRepeatableUpgrades,
   canBuyRepeatableUpgrade,
   buyRepeatableUpgrade,
+  buyRepeatableUpgradeMulti,
   getRepeatableUpgradeCost,
+  getAffordableRepeatableLevels,
 } from "../../engine/upgrades";
 
 const SECTION_ORDER: Array<{ key: string; label: string }> = [
@@ -104,12 +106,34 @@ export async function upgradesScreen(terminal: Terminal, state: GameState): Prom
       if (rep) {
         const level = player.repeatableUpgrades[rep.id] ?? 0;
         const cost = getRepeatableUpgradeCost(rep, level);
-        const confirmed = await terminal.promptConfirm(
-          `Buy ${rep.name} (Lv.${level + 1}) for $${cost.toLocaleString()}?`,
-          "Buy",
-          "Cancel",
-        );
-        if (confirmed) buyRepeatableUpgrade(player, rep);
+        const { maxLevels, totalCost } = getAffordableRepeatableLevels(player, rep);
+        if (player.settings.mode === "sandbox" || maxLevels <= 1) {
+          const confirmed = await terminal.promptConfirm(
+            `Buy ${rep.name} (Lv.${level + 1}) for $${cost.toLocaleString()}?`,
+            "Buy",
+            "Cancel",
+          );
+          if (confirmed) buyRepeatableUpgrade(player, rep);
+        } else {
+          const qtyStr = await terminal.promptText(
+            `Buy ${rep.name} (next costs $${cost.toLocaleString()}) — How many? (1-${maxLevels}, all = $${totalCost.toLocaleString()}):`,
+          );
+          const qty = parseInt(qtyStr, 10);
+          if (!isNaN(qty) && qty > 0) {
+            const actualQty = Math.min(qty, maxLevels);
+            // Recompute total for the chosen quantity
+            let runningCost = 0;
+            for (let i = 0; i < actualQty; i++) {
+              runningCost += getRepeatableUpgradeCost(rep, level + i);
+            }
+            const confirmed = await terminal.promptConfirm(
+              `Buy ${actualQty}× ${rep.name} for $${runningCost.toLocaleString()}?`,
+              "Buy",
+              "Cancel",
+            );
+            if (confirmed) buyRepeatableUpgradeMulti(player, rep, actualQty);
+          }
+        }
         restoreScrollY = scrollY;
       }
     } else {

--- a/apps/games/robot-battle/tests/unit/battle.test.ts
+++ b/apps/games/robot-battle/tests/unit/battle.test.ts
@@ -31,7 +31,7 @@ function makeRobot(overrides?: Partial<Robot>): Robot {
     hands: 2,
     dodge: 0,
     accuracy: 0,
-    level: 1,
+    level: 0,
     exp: 0,
     money: 100,
     bank: 0,
@@ -48,6 +48,7 @@ function makeRobot(overrides?: Partial<Robot>): Robot {
     godMode: false,
     newGamePlusLevel: 0,
     titanDefeated: false,
+    endGameBoss: null,
     ...overrides,
   };
 }
@@ -139,7 +140,7 @@ describe("executeAttack", () => {
     const result = executeAttack(battle, battle.player, battle.enemy, [weapon], rng);
     expect(result.success).toBe(true);
     expect(result.damageDealt).toBe(3);
-    expect(battle.enemy.currentHealth).toBe(9); // 12 HP (10 base + 2 from lv1) - 3 dmg
+    expect(battle.enemy.currentHealth).toBe(7); // 10 HP - 3 dmg
   });
 
   it("fails with insufficient energy", () => {
@@ -203,7 +204,7 @@ describe("useConsumable", () => {
     const battle = createBattle(player, makeRobot());
 
     useConsumable(battle, battle.player, battle.enemy, grenade);
-    expect(battle.enemy.currentHealth).toBe(7); // 12 HP - 5 dmg
+    expect(battle.enemy.currentHealth).toBe(5); // 10 HP - 5 dmg
   });
 
   it("cannot use consumable not in inventory", () => {

--- a/apps/games/robot-battle/tests/unit/save.test.ts
+++ b/apps/games/robot-battle/tests/unit/save.test.ts
@@ -49,6 +49,7 @@ function makeRobot(overrides?: Partial<Robot>): Robot {
     godMode: false,
     newGamePlusLevel: 0,
     titanDefeated: false,
+    endGameBoss: null,
     ...overrides,
   };
 }

--- a/apps/games/robot-battle/tests/unit/upgrades.test.ts
+++ b/apps/games/robot-battle/tests/unit/upgrades.test.ts
@@ -41,6 +41,7 @@ function makeRobot(overrides?: Partial<Robot>): Robot {
     godMode: false,
     newGamePlusLevel: 0,
     titanDefeated: false,
+    endGameBoss: null,
     ...overrides,
   };
 }
@@ -185,11 +186,13 @@ describe("repeatable upgrades", () => {
     expect(allNormalUpgradesPurchased(player)).toBe(true);
   });
 
-  it("cost increases linearly per level", () => {
+  it("cost increases non-linearly per level (flat + 2% compounding)", () => {
     const repHp = listRepeatableUpgrades().find((r) => r.id === "rep-hp")!;
     expect(getRepeatableUpgradeCost(repHp, 0)).toBe(2000);
-    expect(getRepeatableUpgradeCost(repHp, 1)).toBe(3000);
-    expect(getRepeatableUpgradeCost(repHp, 10)).toBe(12000);
+    // Level 1: (2000 + 1000) * 1.02 = 3060
+    expect(getRepeatableUpgradeCost(repHp, 1)).toBe(3060);
+    // Level 10: (2000 + 10000) * 1.02^10 ≈ 14627
+    expect(getRepeatableUpgradeCost(repHp, 10)).toBe(Math.floor(12000 * Math.pow(1.02, 10)));
   });
 
   it("cannot buy repeatable without all normal upgrades (non-sandbox)", () => {


### PR DESCRIPTION
## Summary

- **Level scaling**: every level grants +1 accuracy/dodge/defence/attack and +2 HP, with an extra +1 per New Game+ round (applies to enemies too)
- **Repeatable upgrades**: new `+5 Max Energy`, premium `+3 Attack II` at 10× cost, bulk purchase up to what you can afford, +2% compounding per level on top of the flat increase
- **End-Game Boss**: random boss generated on every 100% Challenge completion — scales to player net worth × 1.25 worth of repeatables, grabs the top weapons/gear/consumables, regenerates on NG+, only shows in the fight menu once every other enemy is defeated, red name, goofy kid-friendly name pool (e.g. "Poopy the Unflushable", "Uncle Meatball the Belcher")
- **New `treasure` cheat code** grants +\$1,000,000
- Changelog updated, `package.json` bumped to `0.13.0`

## Test plan

- [x] `npm test` — 130 unit tests pass
- [x] `npx playwright test` — all e2e tests pass
- [x] `npm run build` — clean TS + Vite build
- [ ] Manual playtest: start fight, verify per-level bonuses show in Details tab
- [ ] Manual playtest: buy repeatable upgrade in bulk, verify cost + stat application
- [ ] Manual playtest: `treasure` cheat grants \$1M
- [ ] Manual playtest: complete 100% challenge run, verify boss appears in fight list with red name, fight it, survive the encounter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-game boss encounters added, including boss generation and NG+ regeneration
  * Purchase multiple levels of repeatable upgrades in one transaction
  * New "treasure" cheat grants large in-game currency boost

* **Balance Changes**
  * Repeatable upgrade costs now use progressive (linear + compounding) scaling
  * Added two new repeatable upgrades for damage and energy
  * NG+ now increases level-based stat and HP scaling

* **Tests**
  * Unit tests updated to reflect new level/HP baselines and end-game boss field
<!-- end of auto-generated comment: release notes by coderabbit.ai -->