### PR TITLE
seo: bulk add keywords to 87 blog posts

### DIFF
--- a/apps/blog/blog/markdown/posts/agent-org-chart.md
+++ b/apps/blog/blog/markdown/posts/agent-org-chart.md
@@ -13,6 +13,13 @@ thumbnail: agent-org-chart-thumb.png
 imgprompt: A simple flat vector slice of pie with the Greek
   letter pi on it, minimal lines, solid pastel colors, no
   shading, clean geometric shapes on a plain background
+keywords:
+  - ai agent orchestration
+  - multi agent architecture
+  - claude code agents
+  - ai agent org chart
+  - agent coordination wiki
+  - mcp server agents
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ai-generate-blog-images.md
+++ b/apps/blog/blog/markdown/posts/ai-generate-blog-images.md
@@ -9,6 +9,12 @@ modified: 2026-01-01
 status: published
 image: ai-generated-blog-images.png
 thumbnail: ai-generated-blog-images-thumb.png
+keywords:
+  - automate blog images with ai
+  - dall-e api blog images
+  - openai image generation
+  - automated thumbnail generation
+  - next.js build pipeline images
 ---
 
 Making blog thumbnails and images is tedious. I don't want to fight with Gimp or whatever and I don't think anyone cares what the image really is. 

--- a/apps/blog/blog/markdown/posts/ai-image-gen-bakeoff.md
+++ b/apps/blog/blog/markdown/posts/ai-image-gen-bakeoff.md
@@ -10,6 +10,12 @@ status: published
 image: ai-image-gen-bakeoff.png
 thumbnail: ai-image-gen-bakeoff-thumb.png
 imgprompt: A cute robot wearing a short chefs hat and holding a paint brush
+keywords:
+  - ai image generator comparison
+  - gpt image vs gemini vs flux
+  - best ai image generation api
+  - dall-e alternative 2026
+  - ai image generation cost comparison
 ---
 
 I wrote about this blog's [automated image generation](/ai-generate-blog-images.html) previously. The short version: `generate-images.mjs` runs before each build, finds posts with missing images, builds a prompt from the `imgprompt` front matter field (or has `gpt-4o-mini` summarize the post), then calls DALL-E 3 to produce a 1024x1024 image.

--- a/apps/blog/blog/markdown/posts/ai-lint-toolkit.md
+++ b/apps/blog/blog/markdown/posts/ai-lint-toolkit.md
@@ -13,6 +13,13 @@ image: ai-lint-toolkit.png
 thumbnail: ai-lint-toolkit-thumb.png
 imgprompt: The Docker whale wearing reading glasses, holding a
   red pen, proofreading a stack of code on a desk
+keywords:
+  - docker linting toolkit
+  - ruff biome hadolint tflint
+  - ai agent code linting
+  - lightweight linter docker image
+  - pre-commit hook linters
+  - megalinter alternative
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ai-native-sdlc-first-try.md
+++ b/apps/blog/blog/markdown/posts/ai-native-sdlc-first-try.md
@@ -14,6 +14,13 @@ imgprompt: "a telescope on the left zooming into a star, connected
   by a dotted line to a microscope on the right examining a circuit
   board, flat minimal vector style, dark charcoal background with
   bright accent colors"
+keywords:
+  - ai native sdlc
+  - prd writer agent
+  - design doc for ai agents
+  - ai product development lifecycle
+  - claude code agent pipeline
+  - automated design documents
 ---
 
 I want to go from "vague idea of something neat to build" to

--- a/apps/blog/blog/markdown/posts/ai-security-toolkit.md
+++ b/apps/blog/blog/markdown/posts/ai-security-toolkit.md
@@ -11,6 +11,13 @@ status: published
 image: ai-security-toolkit.png
 thumbnail: ai-security-toolkit-thumb.png
 imgprompt: The Docker whale wearing a black fedora hat like a hacker
+keywords:
+  - docker security scanning toolkit
+  - semgrep trivy gitleaks
+  - ai agent security scanning
+  - pre-commit security hooks
+  - container vulnerability scanning
+  - secret detection git history
 ---
 
 

--- a/apps/blog/blog/markdown/posts/automated-emails.md
+++ b/apps/blog/blog/markdown/posts/automated-emails.md
@@ -9,6 +9,12 @@ modified: 2019-08-12
 status: published
 image: project-email.png
 thumbnail: project-email-thumb.png
+keywords:
+  - send automated emails without spam
+  - email deliverability automated systems
+  - postfix send only mail server
+  - spf email authentication
+  - cron email alerts
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-api-gateway-iam.md
+++ b/apps/blog/blog/markdown/posts/aws-api-gateway-iam.md
@@ -9,6 +9,12 @@ modified: 2020-01-21
 status: published
 image: aws.png
 thumbnail: aws-thumb.png
+keywords:
+  - aws api gateway iam authentication
+  - api gateway aws_iam authorization
+  - invoke api gateway from python
+  - aws signature v4 python
+  - api gateway lambda iam
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-codepipeline-ecr.md
+++ b/apps/blog/blog/markdown/posts/aws-codepipeline-ecr.md
@@ -9,6 +9,12 @@ modified: 2020-01-15
 status: published
 image: aws.png
 thumbnail: aws-thumb.png
+keywords:
+  - aws codepipeline docker ecr
+  - continuous delivery docker aws
+  - codecommit codebuild ecr pipeline
+  - aws docker ci cd pipeline
+  - buildspec.yml docker image
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-ec2-python.md
+++ b/apps/blog/blog/markdown/posts/aws-ec2-python.md
@@ -9,6 +9,12 @@ modified: 2020-01-09
 status: published
 image: aws.png
 thumbnail: aws-thumb.png
+keywords:
+  - create ec2 instance python boto3
+  - aws ec2 python script
+  - boto3 run instances example
+  - terminate ec2 instance python
+  - aws sdk python ec2
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-ecr.md
+++ b/apps/blog/blog/markdown/posts/aws-ecr.md
@@ -9,6 +9,12 @@ modified: 2019-09-19
 status: published
 image: aws-ecr.png
 thumbnail: aws-ecr-thumb.png
+keywords:
+  - aws ecr setup guide
+  - elastic container registry docker
+  - push docker image to ecr
+  - aws ecr iam permissions
+  - docker login ecr cli
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-fargate.md
+++ b/apps/blog/blog/markdown/posts/aws-fargate.md
@@ -9,6 +9,12 @@ modified: 2019-09-10
 status: published
 image: aws-fargate.png
 thumbnail: aws-fargate-thumb.png
+keywords:
+  - run docker container aws fargate
+  - aws ecs fargate tutorial
+  - deploy container to fargate
+  - aws fargate load balancer
+  - fargate container as a service
 ---
 
 How to run a docker container on AWS ECS (Elastic Compute Cloud)  using the AWS 

--- a/apps/blog/blog/markdown/posts/aws-labmda-codecommit.md
+++ b/apps/blog/blog/markdown/posts/aws-labmda-codecommit.md
@@ -9,6 +9,12 @@ modified: 2020-01-27
 status: published
 image: aws.png
 thumbnail: aws-thumb.png
+keywords:
+  - aws lambda ci cd codebuild
+  - deploy lambda with codepipeline
+  - aws sam lambda deployment
+  - codebuild lambda python
+  - aws serverless ci cd pipeline
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-lambda-iam.md
+++ b/apps/blog/blog/markdown/posts/aws-lambda-iam.md
@@ -9,6 +9,12 @@ modified: 2020-01-09
 status: published
 image: aws-lambda.png
 thumbnail: aws-lambda-thumb.png
+keywords:
+  - aws lambda iam authentication
+  - invoke lambda function python boto3
+  - lambda iam policy example
+  - restrict access aws lambda
+  - aws lambda invoke permission
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws-lambda.md
+++ b/apps/blog/blog/markdown/posts/aws-lambda.md
@@ -9,6 +9,12 @@ modified: 2020-01-08
 status: published
 image: aws-lambda.png
 thumbnail: aws-lambda-thumb.png
+keywords:
+  - aws lambda tutorial python
+  - create lambda function hello world
+  - aws lambda api gateway setup
+  - lambda function basics
+  - aws serverless function example
 ---
 
 This post covers the basics of using AWS Lambda functions.

--- a/apps/blog/blog/markdown/posts/aws-s3-python.md
+++ b/apps/blog/blog/markdown/posts/aws-s3-python.md
@@ -9,6 +9,12 @@ modified: 2019-09-26
 status: published
 image: aws-s3.png
 thumbnail: aws-s3-thumb.png
+keywords:
+  - aws s3 python boto3
+  - upload file to s3 python
+  - download file from s3 python
+  - boto3 s3 example
+  - aws iam s3 access
 ---
 
 

--- a/apps/blog/blog/markdown/posts/aws.md
+++ b/apps/blog/blog/markdown/posts/aws.md
@@ -9,6 +9,12 @@ modified: 2019-11-27
 status: published
 image: aws.png
 thumbnail: aws-thumb.png
+keywords:
+  - aws deep dive
+  - learn aws services
+  - aws ec2 lambda s3 tutorial
+  - amazon web services getting started
+  - aws fargate ecr codepipeline
 ---
 
 **This project is a "Deep Dive":** In a Deep Dive project I'll be investigating

--- a/apps/blog/blog/markdown/posts/blog-website.md
+++ b/apps/blog/blog/markdown/posts/blog-website.md
@@ -9,6 +9,12 @@ modified: 2019-08-01
 status: published
 image: blog.png
 thumbnail: project-blog-thumb.png
+keywords:
+  - build a blog with pelican
+  - static site google cloud storage
+  - pelican blog gcp hosting
+  - google cloud build github
+  - cheap blog hosting with custom domain
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ceph-reference.md
+++ b/apps/blog/blog/markdown/posts/ceph-reference.md
@@ -9,6 +9,12 @@ modified: 2020-03-05
 status: published
 image: ceph.png
 thumbnail: ceph-thumb.png
+keywords:
+  - ceph commands reference
+  - ceph rbd volume management
+  - ceph pool replica count
+  - rbd snapshot rollback
+  - ceph osd pool commands
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/certbot.md
+++ b/apps/blog/blog/markdown/posts/certbot.md
@@ -9,6 +9,12 @@ modified: 2020-01-13
 status: published
 image: LetsEncrypt.png
 thumbnail: LetsEncrypt-thumb.png
+keywords:
+  - letsencrypt certbot tutorial
+  - free https certificate
+  - certbot standalone certificate
+  - install ssl certificate ubuntu
+  - letsencrypt haproxy cert
 ---
 
 

--- a/apps/blog/blog/markdown/posts/claude-code-coderabbit.md
+++ b/apps/blog/blog/markdown/posts/claude-code-coderabbit.md
@@ -12,6 +12,13 @@ status: published
 image: claude-code-coderabbit.png
 thumbnail: claude-code-coderabbit-thumb.png
 imgprompt: A robot holding a magnifying glass reviewing a pull request on a laptop screen
+keywords:
+  - claude code coderabbit setup
+  - ai code review before pull request
+  - coderabbit cli local review
+  - claude code plugin coderabbit
+  - automated code review workflow
+  - coderabbit yaml config
 ---
 
 CodeRabbit is an AI code review tool. It can review your PRs on GitHub / MRs on GitLab

--- a/apps/blog/blog/markdown/posts/claude-hooks.md
+++ b/apps/blog/blog/markdown/posts/claude-hooks.md
@@ -13,6 +13,13 @@ thumbnail: claude-hooks-thumb.png
 imgprompt: A cute cartoon crab wearing a hardhat, holding a
   fishing pole with a standard fishing hook on the line,
   cozy flat illustration style
+keywords:
+  - claude code hooks tutorial
+  - claude code safety hooks
+  - block destructive commands claude
+  - claude code audit log
+  - pretooluse posttooluse hooks
+  - ai coding tool security
 ---
 
 

--- a/apps/blog/blog/markdown/posts/cloudflare-https-frontend.md
+++ b/apps/blog/blog/markdown/posts/cloudflare-https-frontend.md
@@ -9,6 +9,12 @@ modified: 2019-12-02
 status: published
 image: Cloudflare.png
 thumbnail: Cloudflare-thumb.png
+keywords:
+  - cloudflare free https
+  - add https to static site
+  - cloudflare flexible ssl setup
+  - cloudflare always use https
+  - https for google cloud storage site
 ---
 
 

--- a/apps/blog/blog/markdown/posts/cloudflare-mcp.md
+++ b/apps/blog/blog/markdown/posts/cloudflare-mcp.md
@@ -13,6 +13,12 @@ image: cloudflare-mcp.png
 thumbnail: cloudflare-mcp-thumb.png
 imgprompt: a cloud with a small orange shield icon in front of it, flat
   minimal vector style, white background
+keywords:
+  - cloudflare mcp server claude code
+  - query dns records from terminal
+  - cloudflare api mcp integration
+  - claude code cloudflare setup
+  - mcp remote server oauth
 ---
 
 This is a companion to the [GA4 MCP post](/ga4-mcp.html). Same idea,

--- a/apps/blog/blog/markdown/posts/cron-event-triggered-ai-agents-k8s.md
+++ b/apps/blog/blog/markdown/posts/cron-event-triggered-ai-agents-k8s.md
@@ -14,6 +14,13 @@ thumbnail: cron-event-triggered-ai-agents-k8s-thumb.png
 imgprompt: A cute robot crab with clocks for eyes and the
   Kubernetes logo on its stomach, flat vector illustration,
   pastel colors, clean geometric shapes on a plain background
+keywords:
+  - ai agents on kubernetes
+  - cron triggered claude code agent
+  - kubernetes custom controller ai
+  - autonomous ai agent k8s
+  - claude code allowedtools
+  - agenttask crd kubernetes
 ---
 
 

--- a/apps/blog/blog/markdown/posts/dial-home-device.md
+++ b/apps/blog/blog/markdown/posts/dial-home-device.md
@@ -9,6 +9,12 @@ modified: 2019-09-17
 status: published
 image: gear.png
 thumbnail: gear-thumb.png
+keywords:
+  - reverse ssh tunnel remote access
+  - dial home device ssh
+  - persistent reverse ssh tunnel cron
+  - remote server access without vpn
+  - ssh jump box setup
 ---
 
 

--- a/apps/blog/blog/markdown/posts/dns-xfer-godaddy-cloudflare.md
+++ b/apps/blog/blog/markdown/posts/dns-xfer-godaddy-cloudflare.md
@@ -9,6 +9,12 @@ modified: 2019-08-8
 status: published
 image: Cloudflare.png
 thumbnail: Cloudflare-thumb.png
+keywords:
+  - transfer domain godaddy to cloudflare
+  - godaddy to cloudflare migration
+  - domain registrar transfer steps
+  - cloudflare domain registration
+  - move dns to cloudflare
 ---
 
 

--- a/apps/blog/blog/markdown/posts/docker-pelican-image.md
+++ b/apps/blog/blog/markdown/posts/docker-pelican-image.md
@@ -9,6 +9,12 @@ modified: 2019-08-01
 status: published
 image: Docker.png
 thumbnail: docker-thumb.png
+keywords:
+  - docker pelican image
+  - pelican static site generator docker
+  - containerize pelican blog
+  - pelican dockerfile example
+  - docker static website generator
 ---
 
 

--- a/apps/blog/blog/markdown/posts/docker-shared-memory.md
+++ b/apps/blog/blog/markdown/posts/docker-shared-memory.md
@@ -9,6 +9,12 @@ modified: 2019-09-06
 status: published
 image: Docker.png
 thumbnail: docker-thumb.png
+keywords:
+  - docker shared memory size
+  - docker shm-size increase
+  - docker dev shm too small
+  - change docker default shared memory
+  - docker container shared memory configuration
 ---
 
 

--- a/apps/blog/blog/markdown/posts/email-spf.md
+++ b/apps/blog/blog/markdown/posts/email-spf.md
@@ -9,6 +9,12 @@ modified: 2019-08-20
 status: published
 image: project-email.png
 thumbnail: project-email-thumb.png
+keywords:
+  - spf record setup
+  - email spf dns configuration
+  - sender policy framework tutorial
+  - spf txt record example
+  - prevent email spoofing spf
 ---
 
 

--- a/apps/blog/blog/markdown/posts/emails-bash-cron.md
+++ b/apps/blog/blog/markdown/posts/emails-bash-cron.md
@@ -9,6 +9,12 @@ modified: 2019-08-18
 status: published
 image: clock.png
 thumbnail: clock-thumb.png
+keywords:
+  - bash ping alert script
+  - cron job email notification
+  - server monitoring with bash
+  - ping failure email alert
+  - scheduled availability monitoring linux
 ---
 
 This post covers how to create a bash script that runs every minute to send an

--- a/apps/blog/blog/markdown/posts/emails-postfix-ubuntu.md
+++ b/apps/blog/blog/markdown/posts/emails-postfix-ubuntu.md
@@ -9,6 +9,12 @@ modified: 2019-08-15
 status: published
 image: postfix.png
 thumbnail: postfix-thumb.png
+keywords:
+  - postfix send only mail server
+  - configure postfix ubuntu
+  - send email from linux command line
+  - postfix local mail server setup
+  - ubuntu smtp server configuration
 ---
 
 In order to send emails from a VM you need a mail server. Often you can use

--- a/apps/blog/blog/markdown/posts/errors.md
+++ b/apps/blog/blog/markdown/posts/errors.md
@@ -9,6 +9,12 @@ modified: 2020-08-13
 status: published
 image: error.png
 thumbnail: error-thumb.png
+keywords:
+  - docker login error dbus
+  - ceph osd memory leak
+  - chrome err cert revoked localhost
+  - aws ecr get-login ntp error
+  - mac paste weird characters fix
 ---
 
 

--- a/apps/blog/blog/markdown/posts/firebase-circleci-cd.md
+++ b/apps/blog/blog/markdown/posts/firebase-circleci-cd.md
@@ -9,6 +9,12 @@ modified: 2020-01-16
 status: published
 image: google-firestore.png
 thumbnail: google-firestore-thumb.png
+keywords:
+  - firebase circleci continuous deployment
+  - circleci firebase deploy
+  - firebase ci cd pipeline
+  - circleci config yml firebase
+  - automated firebase hosting deploy
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/firebase-hello-world.md
+++ b/apps/blog/blog/markdown/posts/firebase-hello-world.md
@@ -17,6 +17,12 @@ modified: 2026-04-11
 status: published
 image: google-firestore.png
 thumbnail: google-firestore-thumb.png
+keywords:
+  - firebase getting started tutorial
+  - firebase cli deploy hello world
+  - firebase hosting setup
+  - firebase init web app
+  - google firebase basics
 ---
 
 

--- a/apps/blog/blog/markdown/posts/firebase-hello-world.md
+++ b/apps/blog/blog/markdown/posts/firebase-hello-world.md
@@ -17,12 +17,6 @@ modified: 2026-04-11
 status: published
 image: google-firestore.png
 thumbnail: google-firestore-thumb.png
-keywords:
-  - firebase getting started tutorial
-  - firebase cli deploy hello world
-  - firebase hosting setup
-  - firebase init web app
-  - google firebase basics
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ga4-mcp.md
+++ b/apps/blog/blog/markdown/posts/ga4-mcp.md
@@ -11,6 +11,13 @@ status: published
 image: ga4-mcp.png
 thumbnail: ga4-mcp-thumb.png
 imgprompt: three rounded bar chart columns stepping upward left to right, flat colour, shades of orange to bright yellow-orange, minimal, white background
+keywords:
+  - google analytics 4 mcp server
+  - ga4 next js setup
+  - claude code analytics mcp
+  - add google analytics to next js
+  - query ga4 with claude
+  - mcp server google analytics
 ---
 
 Two things in this post. First, wiring up GA4 on this blog, which turns out to

--- a/apps/blog/blog/markdown/posts/gaming-minecraft-feedthebeast.md
+++ b/apps/blog/blog/markdown/posts/gaming-minecraft-feedthebeast.md
@@ -9,6 +9,12 @@ modified: 2019-09-02
 status: published
 image: ftb.png
 thumbnail: ftb-thumb.png
+keywords:
+  - feed the beast server setup
+  - minecraft modded server ubuntu
+  - ftb ultimate reloaded server
+  - private minecraft server hosting
+  - multimc ftb setup
 ---
 
 

--- a/apps/blog/blog/markdown/posts/gcp-cloud-functions.md
+++ b/apps/blog/blog/markdown/posts/gcp-cloud-functions.md
@@ -9,6 +9,12 @@ modified: 2019-10-11
 status: published
 image: google-cloud-functions.png
 thumbnail: google-cloud-functions-thumb.png
+keywords:
+  - google cloud functions tutorial
+  - gcp serverless api python
+  - cloud functions hello world
+  - google cloud functions pricing
+  - deploy cloud function python
 ---
 
 

--- a/apps/blog/blog/markdown/posts/gcp-firestore-python.md
+++ b/apps/blog/blog/markdown/posts/gcp-firestore-python.md
@@ -9,6 +9,13 @@ modified: 2019-10-14
 status: published
 image: google-firestore.png
 thumbnail: google-firestore-thumb.png
+keywords:
+  - google cloud firestore python
+  - firestore vs datastore
+  - firestore python tutorial
+  - gcp firestore read write python
+  - google cloud nosql database python
+  - firestore service account setup
 ---
 
 

--- a/apps/blog/blog/markdown/posts/gcp.md
+++ b/apps/blog/blog/markdown/posts/gcp.md
@@ -9,6 +9,11 @@ modified: 2019-11-28
 status: published
 image: gcp.png
 thumbnail: gcp-thumb.png
+keywords:
+  - google cloud platform deep dive
+  - gcp services overview
+  - learning google cloud platform
+  - gcp tutorial series
 ---
 
 

--- a/apps/blog/blog/markdown/posts/git-reference.md
+++ b/apps/blog/blog/markdown/posts/git-reference.md
@@ -9,6 +9,12 @@ modified: 2019-12-04
 status: published
 image: git.png
 thumbnail: git-thumb.png
+keywords:
+  - git delete file from history
+  - git filter-branch remove file
+  - git merge abort undo
+  - git rename branch
+  - git reference cheat sheet
 ---
 
 

--- a/apps/blog/blog/markdown/posts/github-pages.md
+++ b/apps/blog/blog/markdown/posts/github-pages.md
@@ -9,6 +9,12 @@ modified: 2019-10-25
 status: published
 image: git.png
 thumbnail: git-thumb.png
+keywords:
+  - github pages setup tutorial
+  - github pages custom domain
+  - github pages jekyll configuration
+  - host website on github pages
+  - github pages docs folder
 ---
 
 

--- a/apps/blog/blog/markdown/posts/google-cloud-build.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-build.md
@@ -9,6 +9,12 @@ modified: 2019-12-05
 status: published
 image: google-cloud-build.png
 thumbnail: google-cloud-build-thumb.png
+keywords:
+  - google cloud build tutorial
+  - cloudbuild yaml example
+  - cloud build docker image
+  - gcp ci cd pipeline
+  - cloud build trigger github
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
@@ -9,6 +9,12 @@ modified: 2019-08-09
 status: published
 image: google-cloud-storage.png
 thumbnail: google-cloud-storage-thumb.png
+keywords:
+  - host static website google cloud storage
+  - gcs static website hosting
+  - google cloud storage bucket website
+  - gsutil rsync website deploy
+  - cheap static site hosting gcp
 ---
 
 Google Cloud Storage has a feature where storage buckets can be used as a cost

--- a/apps/blog/blog/markdown/posts/google-container-registry.md
+++ b/apps/blog/blog/markdown/posts/google-container-registry.md
@@ -9,6 +9,12 @@ modified: 2019-08-05
 status: published
 image: google-container-registry.png
 thumbnail: google-container-registry-thumb.png
+keywords:
+  - google container registry tutorial
+  - gcr push docker image
+  - google container registry authentication
+  - gcr vs docker hub
+  - gcloud auth configure docker
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/linear-mcp.md
+++ b/apps/blog/blog/markdown/posts/linear-mcp.md
@@ -10,6 +10,13 @@ status: published
 image: linear-mcp.png
 thumbnail: linear-mcp-thumb.png
 imgprompt: The Linear Logo; a blue circle, top-right-half solid blue, bott-left-half the same blue but striped with 3 black diagonal lines along the lower left half oriented from top-left to bottom-right
+keywords:
+  - linear mcp server setup
+  - ai agent project management
+  - claude code linear integration
+  - nightly ai agent automation
+  - linear api ai workflow
+  - mcp server oauth
 ---
 
 

--- a/apps/blog/blog/markdown/posts/local-llm-m2-air.md
+++ b/apps/blog/blog/markdown/posts/local-llm-m2-air.md
@@ -11,6 +11,13 @@ status: published
 image: local-llm-m2-air.png
 thumbnail: local-llm-m2-air-thumb.png
 imgprompt: A cute robot wearing a small chef's hat with an empty speech bubble
+keywords:
+  - run llm locally on mac
+  - llama.cpp apple silicon
+  - local llm m2 macbook air
+  - qwen3 vs mistral vs deepseek comparison
+  - best local llm for 16gb ram
+  - gguf quantization explained
 ---
 
 No API costs, no data leaving the machine, works offline. The catch is you're

--- a/apps/blog/blog/markdown/posts/local-opencode-setup.md
+++ b/apps/blog/blog/markdown/posts/local-opencode-setup.md
@@ -11,6 +11,13 @@ status: published
 image: opencode.png
 thumbnail: opencode-thumb.png
 imgprompt: Three logos arranged in a triangle; Claude (anthropic logo), Cursor (the IDE), and OpenCode (a dark rectangle with a white inner rectangle cutout). Clean white background, flat design.
+keywords:
+  - opencode vs claude code vs cursor
+  - opencode setup guide
+  - multi-agent ai coding workflow
+  - opencode agents tutorial
+  - ai coding assistant comparison
+  - open source claude code alternative
 ---
 
 # OpenCode vs Cursor vs Claude

--- a/apps/blog/blog/markdown/posts/mac-fix-usb-drive.md
+++ b/apps/blog/blog/markdown/posts/mac-fix-usb-drive.md
@@ -9,6 +9,12 @@ modified: 2019-12-16
 status: published
 image: mac.png
 thumbnail: mac-thumb.png
+keywords:
+  - fix usb drive after boot disk
+  - usb stick shows wrong size mac
+  - diskutil erase usb drive
+  - restore usb full capacity macos
+  - dd shrunken usb partition fix
 ---
 
 

--- a/apps/blog/blog/markdown/posts/mac-vlan-thunderbolt.md
+++ b/apps/blog/blog/markdown/posts/mac-vlan-thunderbolt.md
@@ -9,6 +9,12 @@ modified: 2020-07-23
 status: published
 image: mac.png
 thumbnail: mac-thumb.png
+keywords:
+  - mac vlan tagging thunderbolt ethernet
+  - macos vlan configuration
+  - trunk port macbook testing
+  - virtual interface mac network
+  - 802.1q vlan tag macos
 ---
 
 

--- a/apps/blog/blog/markdown/posts/mermaid-markdown-support.md
+++ b/apps/blog/blog/markdown/posts/mermaid-markdown-support.md
@@ -10,6 +10,12 @@ status: published
 image: mermaid-markdown-support.png
 thumbnail: mermaid-markdown-support-thumb.png
 imgprompt: A minimalist flowchart with 1 black box pointing to 2 boxes
+keywords:
+  - mermaid diagrams in markdown
+  - mermaid next.js blog
+  - render mermaid in remark pipeline
+  - mermaid syntax reference
+  - flowchart sequence diagram markdown
 ---
 
 # (Aside) Leveraging AI for Blog Content

--- a/apps/blog/blog/markdown/posts/openclaw-k8s.md
+++ b/apps/blog/blog/markdown/posts/openclaw-k8s.md
@@ -13,6 +13,13 @@ thumbnail: openclaw-k8s-thumb.png
 imgprompt: A cute cartoon lobster wearing a captain hat
   standing on a ship wheel made of hexagonal pods, floating
   in clouds, flat illustration style
+keywords:
+  - openclaw kubernetes deployment
+  - secure ai agent k8s
+  - hashicorp vault kubernetes secrets
+  - kubernetes network policy ai agent
+  - pod security standards k3s
+  - ai agent security hardening
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openclaw-linear-skill.md
+++ b/apps/blog/blog/markdown/posts/openclaw-linear-skill.md
@@ -13,6 +13,13 @@ thumbnail: openclaw-linear-skill-thumb.png
 imgprompt: A cute cartoon lobster holding a clipboard with
   checkboxes, standing next to a small kanban board with
   colorful sticky notes, cozy flat illustration style
+keywords:
+  - openclaw custom skill tutorial
+  - linear graphql api skill
+  - clawhavoc malicious skills
+  - build your own openclaw skill
+  - ai agent linear integration
+  - self-hosted ai agent security
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openclaw-mvp.md
+++ b/apps/blog/blog/markdown/posts/openclaw-mvp.md
@@ -13,6 +13,13 @@ thumbnail: openclaw-mvp-thumb.png
 imgprompt: A cute cartoon lobster wearing headphones, sitting
   at a small desk with a phone showing chat bubbles, cozy home
   office vibe, flat illustration style
+keywords:
+  - openclaw setup macos
+  - self-hosted ai telegram bot
+  - openclaw gemini free tier
+  - ai chatbot telegram setup
+  - openclaw install guide
+  - personal ai assistant self-hosted
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openrouter-ai-tools.md
+++ b/apps/blog/blog/markdown/posts/openrouter-ai-tools.md
@@ -13,6 +13,14 @@ imgprompt: A friendly cartoon octopus wearing glasses,
   each tentacle holding a different glowing tool or cable,
   plugging them all into a single glowing hub, cozy flat
   illustration style with a soft gradient background
+keywords:
+  - openrouter claude code setup
+  - openrouter api key configuration
+  - unified ai billing openrouter
+  - openrouter opencode openclaw
+  - claude code through openrouter
+  - ai model pricing comparison
+  - custom mcp server openrouter
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openssl-csr-san.md
+++ b/apps/blog/blog/markdown/posts/openssl-csr-san.md
@@ -9,6 +9,12 @@ modified: 2020-10-20
 status: published
 image: openssl-csr-san.png
 thumbnail: openssl-csr-san-thumb.png
+keywords:
+  - openssl csr with san
+  - subject alternative name certificate
+  - err_cert_common_name_invalid fix
+  - openssl san config file
+  - generate csr with subjectaltname
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openstack-aio-ka-metal.md
+++ b/apps/blog/blog/markdown/posts/openstack-aio-ka-metal.md
@@ -9,6 +9,12 @@ modified: 2019-08-13
 status: published
 image: openstack-kolla.png
 thumbnail: openstack-kolla-thumb.png
+keywords:
+  - openstack all in one bare metal
+  - kolla-ansible single server install
+  - openstack rocky install guide
+  - openstack on intel nuc
+  - kolla-ansible vlan provider network
 ---
 
 This guide installs OpenStack on a single metal server.

--- a/apps/blog/blog/markdown/posts/openstack-aio-ka-vm.md
+++ b/apps/blog/blog/markdown/posts/openstack-aio-ka-vm.md
@@ -9,6 +9,12 @@ modified: 2019-08-11
 status: published
 image: openstack-kolla.png
 thumbnail: openstack-kolla-thumb.png
+keywords:
+  - openstack all in one vm install
+  - kolla-ansible vm deployment
+  - openstack dev environment setup
+  - openstack rocky kolla-ansible guide
+  - openstack on openstack nested
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/openstack-ansible.md
+++ b/apps/blog/blog/markdown/posts/openstack-ansible.md
@@ -9,6 +9,12 @@ modified: 2019-12-03
 status: published
 image: openstack.png
 thumbnail: openstack-thumb.png
+keywords:
+  - openstack ansible modules tutorial
+  - ansible create openstack instance
+  - openstack automation with ansible
+  - os_server ansible example
+  - openstack networking ansible playbook
 ---
 
 **Assumption:** To avoid dealing with varying OpenStack policy configuration,

--- a/apps/blog/blog/markdown/posts/openstack-fix-cli.md
+++ b/apps/blog/blog/markdown/posts/openstack-fix-cli.md
@@ -9,6 +9,11 @@ modified: 2020-06-25
 status: published
 image: openstack.png
 thumbnail: openstack-thumb.png
+keywords:
+  - openstack cli no module named queue
+  - python-openstackclient import error fix
+  - openstack cli python2 broken
+  - importerror no module named queue openstack
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openstack-kolla-custom-plugin.md
+++ b/apps/blog/blog/markdown/posts/openstack-kolla-custom-plugin.md
@@ -9,6 +9,12 @@ modified: 2019-08-26
 status: published
 image: openstack-kolla.png
 thumbnail: openstack-kolla-thumb.png
+keywords:
+  - openstack kolla custom docker image
+  - kolla build custom cinder plugin
+  - openstack cinder pure storage
+  - modify kolla container images
+  - kolla template override
 ---
 
 

--- a/apps/blog/blog/markdown/posts/openstack.md
+++ b/apps/blog/blog/markdown/posts/openstack.md
@@ -9,6 +9,13 @@ modified: 2019-11-25
 status: published
 image: openstack.png
 thumbnail: openstack-thumb.png
+keywords:
+  - openstack private cloud
+  - openstack vs vmware
+  - install openstack kolla ansible
+  - why use openstack
+  - openstack deep dive
+  - private cloud on premises
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ops-cheatsheet.md
+++ b/apps/blog/blog/markdown/posts/ops-cheatsheet.md
@@ -9,6 +9,13 @@ modified: 2020-11-09
 status: published
 image: gear.png
 thumbnail: gear-thumb.png
+keywords:
+  - linux operations cheatsheet
+  - tcpdump examples
+  - vim find and replace
+  - passwordless sudo ubuntu
+  - bash trap exit cleanup
+  - loopback volume ubuntu
 ---
 
 

--- a/apps/blog/blog/markdown/posts/oss-img-gen.md
+++ b/apps/blog/blog/markdown/posts/oss-img-gen.md
@@ -11,6 +11,13 @@ status: published
 image: oss-img-gen-knight.png
 thumbnail: oss-img-gen-knight-thumb.png
 imgprompt: A tiny robot dungeon master painting miniature fantasy character portraits at a glowing desk
+keywords:
+  - comfyui apple silicon setup
+  - comfyui rest api local
+  - ip adapter character consistency
+  - sdxl on macbook m2
+  - comfyui image generation api
+  - tabletop rpg ai art
 ---
 
 I'm building a tabletop RPG game that generates images on the fly: character portraits,

--- a/apps/blog/blog/markdown/posts/packet-tracing-reference.md
+++ b/apps/blog/blog/markdown/posts/packet-tracing-reference.md
@@ -9,6 +9,12 @@ modified: 2020-06-04
 status: published
 image: gear.png
 thumbnail: gear-thumb.png
+keywords:
+  - tcpdump filter examples
+  - tshark capture http traffic
+  - packet capture ubuntu
+  - tcpdump filter by port and host
+  - wireshark command line tshark
 ---
 
 

--- a/apps/blog/blog/markdown/posts/pelican-dev-environment.md
+++ b/apps/blog/blog/markdown/posts/pelican-dev-environment.md
@@ -9,6 +9,11 @@ modified: 2019-08-04
 status: published
 image: gear.png
 thumbnail: gear-thumb.png
+keywords:
+  - pelican local development docker
+  - pelican static site preview
+  - pelican autoreload dev server
+  - pelican docker container setup
 ---
 
 

--- a/apps/blog/blog/markdown/posts/playwright-mcp.md
+++ b/apps/blog/blog/markdown/posts/playwright-mcp.md
@@ -12,6 +12,13 @@ status: published
 image: playwright-mcp.png
 thumbnail: playwright-mcp-thumb.png
 imgprompt: flat colour comedy and tragedy masks, comedy green, tragedy red, comedy half in front of tragedy.
+keywords:
+  - playwright mcp claude code
+  - ai agent browser testing
+  - gherkin playwright test generation
+  - claude code verify changes browser
+  - playwright mcp setup
+  - ai coding agent visual testing
 ---
 
 Playwright MCP gives Claude Code a real browser to drive. Coding agents are kind of

--- a/apps/blog/blog/markdown/posts/python-ceph.md
+++ b/apps/blog/blog/markdown/posts/python-ceph.md
@@ -9,6 +9,12 @@ modified: 2020-02-03
 status: published
 image: ceph.png
 thumbnail: ceph-thumb.png
+keywords:
+  - python ceph rados example
+  - python rbd library
+  - ceph python api
+  - manage ceph from python
+  - python ceph block device
 ---
 
 

--- a/apps/blog/blog/markdown/posts/python-cheat-sheet.md
+++ b/apps/blog/blog/markdown/posts/python-cheat-sheet.md
@@ -9,6 +9,13 @@ modified: 2019-09-26
 status: published
 image: python.png
 thumbnail: python-thumb.png
+keywords:
+  - python cheat sheet
+  - pylint disable comment
+  - python list comprehension examples
+  - python jinja2 template example
+  - python replace string in file
+  - python mysql query example
 ---
 
 

--- a/apps/blog/blog/markdown/posts/python-http-transfer.md
+++ b/apps/blog/blog/markdown/posts/python-http-transfer.md
@@ -9,6 +9,11 @@ modified: 2020-01-13
 status: published
 image: python.png
 thumbnail: python-thumb.png
+keywords:
+  - python simplehttpserver file transfer
+  - transfer files linux to windows
+  - python http server share files
+  - windows download from linux server
 ---
 
 

--- a/apps/blog/blog/markdown/posts/python-pypi.md
+++ b/apps/blog/blog/markdown/posts/python-pypi.md
@@ -9,6 +9,12 @@ modified: 2019-10-2
 status: published
 image: pypi.png
 thumbnail: pypi-thumb.png
+keywords:
+  - upload python package pypi
+  - pypi setup.py example
+  - publish python package pip
+  - twine upload pypi
+  - python package distribution
 ---
 
 

--- a/apps/blog/blog/markdown/posts/python-sql-json.md
+++ b/apps/blog/blog/markdown/posts/python-sql-json.md
@@ -9,6 +9,12 @@ modified: 2019-09-05
 status: published
 image: python.png
 thumbnail: python-thumb.png
+keywords:
+  - python read json from mysql
+  - python update json sql database
+  - mariadb json column python
+  - python mysql connector json
+  - edit json in database python
 ---
 
 

--- a/apps/blog/blog/markdown/posts/rhel-virtio-initrd.md
+++ b/apps/blog/blog/markdown/posts/rhel-virtio-initrd.md
@@ -9,6 +9,12 @@ modified: 2020-10-21
 status: published
 image: openstack.png
 thumbnail: openstack-thumb.png
+keywords:
+  - rhel virtio drivers initrd
+  - openstack vm dracut prompt
+  - inject kvm drivers rhel
+  - migrate vmware to openstack rhel
+  - dracut add virtio drivers
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ruler-cross-tool-ai-rules.md
+++ b/apps/blog/blog/markdown/posts/ruler-cross-tool-ai-rules.md
@@ -12,6 +12,13 @@ status: published
 image: ruler-cross-tool-ai-rules.png
 thumbnail: ruler-cross-tool-ai-rules-thumb.png
 imgprompt: A tiny robot holding a ruler standing in front of multiple computer screens each showing a different code editor
+keywords:
+  - ruler ai coding rules
+  - share rules across cursor claude code
+  - agents.md vs claude.md
+  - monorepo ai assistant config
+  - cross tool ai instructions
+  - ruler setup tutorial
 ---
 
 I use Cursor and Claude Code, sometimes Codex, and I'm about to try OpenCode.

--- a/apps/blog/blog/markdown/posts/secure-my-laptop.md
+++ b/apps/blog/blog/markdown/posts/secure-my-laptop.md
@@ -11,6 +11,13 @@ thumbnail: secure-my-laptop-thumb.png
 imgprompt: cartoon boy with messy hair and gap-toothed grin
   sitting at a laptop surrounded by security padlocks, flat
   vector illustration style, warm pastel colors
+keywords:
+  - autonomous ai agent security
+  - claude code laptop security ansible
+  - ralph loop ai agent
+  - macos security hardening ansible
+  - lynis macos security audit
+  - ai agent autonomous loop
 ---
 
 I had Claude credits left in my week and wanted to secure my agent-dediced macbook. It

--- a/apps/blog/blog/markdown/posts/ubuntu-bionic-wifi.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-bionic-wifi.md
@@ -9,6 +9,12 @@ modified: 2020-03-09
 status: published
 image: wifi.png
 thumbnail: wifi-thumb.png
+keywords:
+  - ubuntu 18.04 connect wifi command line
+  - ubuntu server wpa supplicant
+  - netplan wifi configuration
+  - ubuntu bionic wireless setup
+  - connect ubuntu server to wifi
 ---
 
 # Setup

--- a/apps/blog/blog/markdown/posts/ubuntu-nfs-server.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-nfs-server.md
@@ -9,6 +9,12 @@ modified: 2020-03-09
 status: published
 image: ubuntu.png
 thumbnail: ubuntu-thumb.png
+keywords:
+  - ubuntu nfs server setup
+  - nfs server ubuntu 18.04
+  - install nfs kernel server
+  - nfs client mount ubuntu
+  - linux nfs exports configuration
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ubuntu-trust-corporate-ca.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-trust-corporate-ca.md
@@ -9,6 +9,12 @@ modified: 2020-01-08
 status: published
 image: gear.png
 thumbnail: gear-thumb.png
+keywords:
+  - ubuntu trust corporate ca certificate
+  - add custom ca certificate ubuntu
+  - update-ca-certificates ubuntu
+  - trust self signed certificate linux
+  - corporate ssl certificate ubuntu
 ---
 
 

--- a/apps/blog/blog/markdown/posts/ubuntu-wifi-to-wired-router.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-wifi-to-wired-router.md
@@ -9,6 +9,12 @@ modified: 2019-08-20
 status: published
 image: wifi.png
 thumbnail: wifi-thumb.png
+keywords:
+  - ubuntu server as wireless router
+  - share wifi to ethernet ubuntu
+  - ubuntu iptables nat masquerade
+  - linux wifi to wired bridge
+  - ubuntu ip forwarding setup
 ---
 
 

--- a/apps/blog/blog/markdown/posts/using-agents-better.md
+++ b/apps/blog/blog/markdown/posts/using-agents-better.md
@@ -14,6 +14,13 @@ thumbnail: using-agents-better-thumb.png
 imgprompt: seven small happy crabs in a row, each a different pastel
   colour, flat minimal vector style, plenty of white space around them,
   white background
+keywords:
+  - claude code agent best practices
+  - multi agent ai architecture
+  - claude code subagents
+  - ai agent delegation patterns
+  - anthropic agent design research
+  - coding agent prompt engineering
 ---
 
 

--- a/apps/blog/blog/markdown/posts/vim-spellcheck.md
+++ b/apps/blog/blog/markdown/posts/vim-spellcheck.md
@@ -9,6 +9,12 @@ modified: 2019-10-25
 status: published
 image: vim.png
 thumbnail: vim-thumb.png
+keywords:
+  - vim spell check
+  - enable spell check vim
+  - vim spellcheck commands
+  - vim spelling suggestions
+  - vim spelllang
 ---
 
 

--- a/apps/blog/blog/markdown/posts/wiki-rag.md
+++ b/apps/blog/blog/markdown/posts/wiki-rag.md
@@ -14,6 +14,13 @@ imgprompt: A cartoon robot sitting at a desk with magnifying
   glass, examining floating documents that connect with
   glowing lines, warm library setting, flat illustration
   style with soft gradients, bookshelves in background
+keywords:
+  - build rag pipeline python
+  - faiss vector search tutorial
+  - retrieval augmented generation example
+  - openrouter embeddings api
+  - python faiss semantic search
+  - rag chunking strategy
 ---
 
 The [bot-wiki post](/bot-wiki.html) introduced a structured wiki

--- a/apps/blog/blog/markdown/posts/windows-kvm-command-line.md
+++ b/apps/blog/blog/markdown/posts/windows-kvm-command-line.md
@@ -9,6 +9,13 @@ modified: 2020-06-05
 status: published
 image: ubuntu.png
 thumbnail: ubuntu-thumb.png
+keywords:
+  - create windows vm kvm command line
+  - virt-install windows server
+  - kvm virtio drivers windows
+  - windows kvm ubuntu 18.04
+  - virsh create windows vm
+  - kvm network bridge setup
 ---
 
 # Install KVM

--- a/apps/blog/blog/markdown/posts/windows-kvm-drivers.md
+++ b/apps/blog/blog/markdown/posts/windows-kvm-drivers.md
@@ -9,6 +9,12 @@ modified: 2019-12-17
 status: published
 image: windows.png
 thumbnail: windows-thumb.png
+keywords:
+  - inject kvm drivers windows image
+  - windows virtio drivers openstack
+  - dism add driver windows 10
+  - convert vmdk to qcow2 windows
+  - windows image openstack glance
 ---
 
 ### Table of Contents

--- a/apps/blog/blog/markdown/posts/writing-pelican-content.md
+++ b/apps/blog/blog/markdown/posts/writing-pelican-content.md
@@ -9,6 +9,12 @@ modified: 2019-08-03
 status: published
 image: pelican.png
 thumbnail: pelican-thumb.png
+keywords:
+  - pelican static site generator tutorial
+  - pelican markdown blog
+  - pelican blog setup
+  - python static website generator
+  - pelican content format
 ---
 
 # What is Pelican

--- a/apps/blog/blog/markdown/posts/x11-forwarding-ubuntu18.md
+++ b/apps/blog/blog/markdown/posts/x11-forwarding-ubuntu18.md
@@ -9,6 +9,12 @@ modified: 2019-08-19
 status: published
 image: x-windows.png
 thumbnail: x-windows-thumb.png
+keywords:
+  - x11 forwarding ssh ubuntu
+  - run chrome remote ubuntu server
+  - ssh x11 forwarding mac
+  - xquartz ssh forwarding
+  - launch gui application over ssh
 ---
 
 


### PR DESCRIPTION
## Summary

- Added `keywords` frontmatter (4-7 search-query-style phrases) to all 87 published blog posts that were missing them
- Added missing `summary` to ssh-tunnel.md
- The nightly seo-bot was doing this one post per night — this completes ~3 months of bot work in one PR

## Details

The seo-bot's nightly runs showed a clear pattern: every run picked one post, rewrote/added the meta description, and added keywords. With 87 posts missing keywords, this would take until July at one-per-night pace.

Keywords were generated by reading each post's content and producing realistic search queries someone would use to find that content. Draft posts (11) were intentionally skipped since they aren't indexed.

## Test plan

- [x] Blog builds cleanly (`npm run build`)
- [ ] Spot-check a few posts to verify keyword quality
- [ ] Verify frontmatter YAML is valid (build success confirms this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added SEO-focused keyword metadata to over 100 blog posts, enhancing search engine optimization and content discoverability. Keywords cover diverse technical topics including AI agents, cloud infrastructure platforms (AWS, GCP, OpenStack), containerization, security tools, serverless functions, DevOps practices, and development frameworks, improving ability to find relevant content through search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->