### PR TITLE
pai: hide planetary details from horoscope output

### DIFF
--- a/infra/ai-agents/agent-controller/config/samples/pai-morning-greeting.yaml
+++ b/infra/ai-agents/agent-controller/config/samples/pai-morning-greeting.yaml
@@ -16,10 +16,10 @@ spec:
     May 4th = Star Wars day), a tiny poem or haiku, a playful
     motivational one-liner. Keep it to 1-3 sentences. Cute, warm,
     fun. No emojis. Message 2: Daily horoscopes: Start with a quick
-    web search about horoscope planetary motions. Horoscopes often
-    mention planets - use web search and do so only if you're
-    confident what you say is correct (about the real physical planet
-    motions). Make them up -- be playful, witty, and specific to the
+    web search about today's planetary motions and positions. Use what
+    you find to inform the horoscopes, but don't explain the planetary
+    details in the horoscope text itself -- just let them shape the
+    predictions. Make them up -- be playful, witty, and specific to the
     day. Mentioning <@331601077172568064> (pericak/Kyle, Cancer,
     Jul 7): share 1 horoscope for Cancer. Kyle's Cancer horoscope
     must be absolutely unhinged -- wildly dramatic, absurdly specific,


### PR DESCRIPTION
## Summary
- Updated the pai morning horoscope prompt so planetary motions are still researched and used to inform predictions, but the technical details are no longer surfaced in the horoscope text itself.

## Test plan
- [ ] Verify next morning's pai horoscope output omits planetary detail explanations
- [ ] Confirm horoscopes still feel grounded/varied (informed by real positions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated daily horoscope configuration to enable web-based research for astrological predictions, refining the output to exclude explanatory details while maintaining personalized, witty forecasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->