### PR TITLE
seo: bulk rewrite 66 short summaries to SEO sweet spot

### DIFF
--- a/apps/blog/blog/markdown/posts/ai-generate-blog-images.md
+++ b/apps/blog/blog/markdown/posts/ai-generate-blog-images.md
@@ -1,6 +1,6 @@
 ---
 title: Automating Blog Images with OpenAI
-summary: Using Codex and DALL·E to create blog title art on the fly
+summary: How this blog auto-generates post thumbnails at build time using OpenAI's DALL-E 3 API, gpt-4o-mini for prompts, and Sharp for 70x70 resizing.
 slug: ai-generated-blog-images
 category: ai
 tags: AI, OpenAI, Blog

--- a/apps/blog/blog/markdown/posts/ai-image-gen-bakeoff.md
+++ b/apps/blog/blog/markdown/posts/ai-image-gen-bakeoff.md
@@ -1,6 +1,6 @@
 ---
 title: "AI Image Generator Bakeoff"
-summary: Comparing GPT Image 1.5, Nano Banana, and Flux 2 Max for blog image generation
+summary: "Head-to-head comparison of GPT Image 1.5, Nano Banana Pro, and Flux 2 Max APIs for blog image generation: setup, pricing, and real output quality."
 slug: ai-image-gen-bakeoff
 category: ai
 tags: AI, Images, OpenAI, Flux, Nano Banana

--- a/apps/blog/blog/markdown/posts/automated-emails.md
+++ b/apps/blog/blog/markdown/posts/automated-emails.md
@@ -1,6 +1,6 @@
 ---
 title: Project - Automated Emails
-summary: Sending emails from automated systems without having them marked as SPAM.
+summary: A project exploring how to send emails from automated systems without hitting spam filters, covering Postfix send-only servers, cron alerts, and SPF setup.
 slug: project-email
 tags: email
 category: projects

--- a/apps/blog/blog/markdown/posts/aws-api-gateway-iam.md
+++ b/apps/blog/blog/markdown/posts/aws-api-gateway-iam.md
@@ -1,6 +1,6 @@
 ---
 title: Authenticating with AWS IAM in AWS API Gateway
-summary: Enabling IAM authentication on API Gateway and building a client
+summary: Lock down an AWS API Gateway endpoint with IAM auth, wire it to a Python Lambda, and call it from a signed client using policies and access keys.
 slug: aws-api-gateway-iam
 category: cloud
 tags: AWS, API Gateway, Python

--- a/apps/blog/blog/markdown/posts/aws-codepipeline-ecr.md
+++ b/apps/blog/blog/markdown/posts/aws-codepipeline-ecr.md
@@ -1,6 +1,6 @@
 ---
 title: CodePipeline - Continuous Delivery to AWS ECR
-summary: Automatically rebuild and deploy docker images on AWS
+summary: Wire up AWS CodeCommit, CodePipeline, and CodeBuild with a buildspec.yml to auto-build Docker images and push them to ECR on every commit.
 slug: aws-codepipeline-ecr
 category: cloud
 tags: AWS, Docker, CICD, CodePipeline, CodeCommit, CodeBuild

--- a/apps/blog/blog/markdown/posts/aws-ec2-python.md
+++ b/apps/blog/blog/markdown/posts/aws-ec2-python.md
@@ -1,6 +1,6 @@
 ---
 title: Create & Terminate EC2 Instances from Python
-summary: Creating and destroying VMs on EC2 from Python
+summary: Launch and terminate EC2 instances from Python using boto3, with a working example covering Ubuntu AMIs, security groups, tags, and wait_until_running.
 slug: aws-ec2-python
 category: cloud
 tags: AWS, EC2, Python

--- a/apps/blog/blog/markdown/posts/aws-ecr.md
+++ b/apps/blog/blog/markdown/posts/aws-ecr.md
@@ -1,6 +1,6 @@
 ---
 title: AWS ECR - Elastic Container Registry - Basics
-summary: Creating and operating a Docker registry on AWS with custom users
+summary: Set up an AWS Elastic Container Registry repo, create least-privilege IAM groups for push and pull access, and connect Docker using the AWS CLI.
 slug: aws-ecr
 category: cloud
 tags: AWS, Docker

--- a/apps/blog/blog/markdown/posts/aws-fargate.md
+++ b/apps/blog/blog/markdown/posts/aws-fargate.md
@@ -1,6 +1,6 @@
 ---
 title: AWS Fargate - Basics
-summary: How to run a docker container on AWS Fargate from the web console
+summary: Step-by-step for launching a Docker container on AWS ECS Fargate from the web console, including task definitions, load balancer setup, and ECR image URLs.
 slug: aws-fargate
 category: cloud
 tags: AWS, Docker

--- a/apps/blog/blog/markdown/posts/aws-labmda-codecommit.md
+++ b/apps/blog/blog/markdown/posts/aws-labmda-codecommit.md
@@ -1,6 +1,6 @@
 ---
 title: AWS CodeBuild CICD - Deploy to Lambda
-summary: Testing and automatically deploying lambda functions using CodeBuild
+summary: Build a CI/CD pipeline for Python Lambda functions using CodeCommit, CodeBuild, and AWS SAM templates to test and auto-deploy on every commit.
 slug: aws-labmda-cicd
 category: cloud
 tags: AWS, Lambda, Python, CodeBuild

--- a/apps/blog/blog/markdown/posts/aws-lambda-iam.md
+++ b/apps/blog/blog/markdown/posts/aws-lambda-iam.md
@@ -1,6 +1,6 @@
 ---
 title: IAM Auth for Lambda
-summary: Authenticating specific Lambda functions for use from Python
+summary: Restrict access to a specific AWS Lambda function using an IAM policy scoped to its ARN, then invoke it from Python with boto3 and access keys.
 slug: aws-lambda-iam
 category: cloud
 tags: AWS, Lambda, Python

--- a/apps/blog/blog/markdown/posts/aws-lambda.md
+++ b/apps/blog/blog/markdown/posts/aws-lambda.md
@@ -1,6 +1,6 @@
 ---
 title: AWS Lambda - Basics
-summary: Basics of creating a simple API-driven AWS Lambda function
+summary: Create your first AWS Lambda function in Python, define a test event, and understand pricing per request and per GB-second of execution duration.
 slug: aws-lambda
 category: cloud
 tags: AWS, Lambda

--- a/apps/blog/blog/markdown/posts/aws-s3-python.md
+++ b/apps/blog/blog/markdown/posts/aws-s3-python.md
@@ -1,6 +1,6 @@
 ---
 title: Using AWS S3 from Python
-summary: Saving and reading files from S3 using python and a dedicated IAM user.
+summary: Upload and download files to AWS S3 from Python using boto3, with IAM policies, user groups, and a dedicated service account for programmatic access.
 slug: aws-s3-python
 category: cloud
 tags: AWS,python,S3

--- a/apps/blog/blog/markdown/posts/aws.md
+++ b/apps/blog/blog/markdown/posts/aws.md
@@ -1,6 +1,6 @@
 ---
 title: "Project: AWS Deep Dive"
-summary: An ongoing in-depth exploration of Amazon Web Services
+summary: An ongoing deep-dive project exploring AWS services hands-on, covering EC2, Lambda, S3, ECR, Fargate, API Gateway, and CodePipeline with working examples.
 slug: aws
 tags: AWS
 category: projects

--- a/apps/blog/blog/markdown/posts/bot-wiki.md
+++ b/apps/blog/blog/markdown/posts/bot-wiki.md
@@ -1,6 +1,6 @@
 ---
 title: "Bot-Wiki: A Knowledge Base for Robots"
-summary: Building a structured wiki designed for RAG retrieval and AI agents, right alongside the blog.
+summary: Adding a structured wiki to the blog designed for AI agents and RAG pipelines, with machine-readable frontmatter, keyword lists, and cross-references.
 slug: bot-wiki
 category: ai
 tags: AI, RAG, wiki, Bot-Wiki, knowledge-base

--- a/apps/blog/blog/markdown/posts/certbot.md
+++ b/apps/blog/blog/markdown/posts/certbot.md
@@ -1,6 +1,6 @@
 ---
 title: Free HTTPS Certs with LetsEncrypt's Certbot
-summary: Installing and using certbot from LestEncrypt to get a free HTTPS cert
+summary: Install LetsEncrypt's certbot on Ubuntu and issue a free HTTPS certificate using the standalone HTTP challenge, then convert the files for HAProxy use.
 slug: certbot
 category: systems administration
 tags: HTTPS

--- a/apps/blog/blog/markdown/posts/cloudflare-https-frontend.md
+++ b/apps/blog/blog/markdown/posts/cloudflare-https-frontend.md
@@ -1,6 +1,6 @@
 ---
 title: CloudFlare HTTPS CDN
-summary: Using Cloudflare to provide HTTPS to an HTTP static site
+summary: Put HTTPS in front of an HTTP-only static site like Google Cloud Storage using Cloudflare's Flexible SSL mode and the Always Use HTTPS redirect.
 slug: cloudflare-https
 category: development
 tags: cloudflare

--- a/apps/blog/blog/markdown/posts/dial-home-device.md
+++ b/apps/blog/blog/markdown/posts/dial-home-device.md
@@ -1,6 +1,6 @@
 ---
 title: "Remote Access: Build a Dial-Home Device"
-summary: Building a remote jump-box that dials home to establish a session
+summary: Build a persistent reverse SSH tunnel from an Ubuntu box at a customer site to your own pivot VPS, so you can remote in without a VPN.
 slug: dial-home-device
 category: systems administration
 tags: remote access, Ubuntu

--- a/apps/blog/blog/markdown/posts/dns-xfer-godaddy-cloudflare.md
+++ b/apps/blog/blog/markdown/posts/dns-xfer-godaddy-cloudflare.md
@@ -1,6 +1,6 @@
 ---
 title: Transfer Domain from GoDaddy to Cloudflare
-summary: How I moved my main domain from GoDaddy to Cloudflare, making life easier.
+summary: Transfer a domain from GoDaddy to Cloudflare for faster DNS propagation and cheaper registration. Covers unlocking, auth codes, and finalizing the move.
 slug: dns-xfer-godaddy-cloudflare
 category: systems administration
 date: 2019-08-8

--- a/apps/blog/blog/markdown/posts/docker-pelican-image.md
+++ b/apps/blog/blog/markdown/posts/docker-pelican-image.md
@@ -1,6 +1,6 @@
 ---
 title: Building a Docker Pelican Image
-summary: Create a Docker image for Pelican, to convert markdown content into static website files.
+summary: Build a reusable Docker image that runs Pelican to convert markdown into a static site, bundling a theme from GitHub and the series plugin in one layer.
 slug: docker-pelican-image
 category: development
 tags: docker, Pelican

--- a/apps/blog/blog/markdown/posts/docker-shared-memory.md
+++ b/apps/blog/blog/markdown/posts/docker-shared-memory.md
@@ -1,6 +1,6 @@
 ---
 title: Docker Shared Memory (/dev/sdh)
-summary: Using a high-performance shared memory volume in Docker containers
+summary: "Docker's 64MB /dev/shm default is tiny. Raise it per-container with --shm-size, set a daemon-wide default in daemon.json, or remount /dev/shm on the host."
 slug: docker-shared-memory
 category: development
 tags: Docker

--- a/apps/blog/blog/markdown/posts/email-spf.md
+++ b/apps/blog/blog/markdown/posts/email-spf.md
@@ -1,6 +1,6 @@
 ---
 title: SPF for Trusted Emails
-summary: Configuring which hosts are trusted to send emails for any domain using SPF.
+summary: Configure a Sender Policy Framework DNS record so mail servers trust emails from your domain. Covers finding your external IP and setting the TXT record.
 slug: email-spf
 category: systems administration
 tags: email

--- a/apps/blog/blog/markdown/posts/emails-bash-cron.md
+++ b/apps/blog/blog/markdown/posts/emails-bash-cron.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduled Availability Email Alerts
-summary: Sending cron-scheduled ping failure alerts using a bash script
+summary: Write a cron-driven bash script that pings a host every minute and sends a throttled email alert on failure, using the mail command and a token file.
 slug: emails-bash-cron
 category: systems administration
 tags: email, bash

--- a/apps/blog/blog/markdown/posts/emails-postfix-ubuntu.md
+++ b/apps/blog/blog/markdown/posts/emails-postfix-ubuntu.md
@@ -1,6 +1,6 @@
 ---
 title: Postfix Send-Only Mail Service
-summary: Deploy and configure Postfix as a local send-only mail server.
+summary: Install and configure Postfix on Ubuntu as a local send-only SMTP server for alert emails, including hostname setup, main.cf tuning, and the mailutils tools.
 slug: emails-postfix-ubuntu
 category: systems administration
 tags: email,postfix

--- a/apps/blog/blog/markdown/posts/errors.md
+++ b/apps/blog/blog/markdown/posts/errors.md
@@ -1,6 +1,6 @@
 ---
 title: Error Messages, Codes, & Stack Traces
-summary: Error's I've seen and how I fixed them, if I fixed them.
+summary: A running reference of error messages I've hit and the fixes that worked. Includes Docker D-Bus login, Ceph OSD memory, Chrome cert errors, and AWS ECR NTP.
 slug: errors
 category: reference pages
 tags: AWS, Pure Storage, Mac OS

--- a/apps/blog/blog/markdown/posts/firebase-circleci-cd.md
+++ b/apps/blog/blog/markdown/posts/firebase-circleci-cd.md
@@ -1,6 +1,6 @@
 ---
 title: "CircleCI: Continuous Delivery for Firebase"
-summary: A very simple CD setup for a basic hosting Firebase app.
+summary: "Set up continuous deployment for a Firebase Hosting app using CircleCI, a firebase login:ci token, and a minimal config.yml that runs firebase deploy."
 slug: firebase-circleci-cd
 category: development
 tags: Firebase

--- a/apps/blog/blog/markdown/posts/gaming-minecraft-feedthebeast.md
+++ b/apps/blog/blog/markdown/posts/gaming-minecraft-feedthebeast.md
@@ -1,6 +1,6 @@
 ---
 title: Private Minecraft Feed-The-Beast Server & Client Setup
-summary: Hosting a private modded Minecraft server and connecting to it using various clients.
+summary: Run a private FTB Ultimate Reloaded modded Minecraft server on an Ubuntu 16.04 VM with 12GB RAM, and connect using MultiMC or the Feed The Beast launcher.
 slug: gaming-minecraft-feedthebeast
 category: gaming
 tags: minecraft

--- a/apps/blog/blog/markdown/posts/gcp-cloud-functions.md
+++ b/apps/blog/blog/markdown/posts/gcp-cloud-functions.md
@@ -1,6 +1,6 @@
 ---
 title: "Google Cloud Functions: Basics"
-summary: Building a simple servless API on Google Cloud Platform's Cloud Functions
+summary: Deploy a Python 3.7 HTTP-triggered Google Cloud Function that returns the caller's IP, with notes on pricing, invocation costs, and testing from the console.
 slug: gcp-cloud-functions
 category: cloud
 tags: gcp, api

--- a/apps/blog/blog/markdown/posts/gcp-firestore-python.md
+++ b/apps/blog/blog/markdown/posts/gcp-firestore-python.md
@@ -1,6 +1,6 @@
 ---
 title: Google Cloud Firestore Basics - Python
-summary: Reading and writing Firestore entries from local python, and some comparisons with Datastore
+summary: Read and write Google Cloud Firestore documents from Python, with pricing comparisons against Datastore mode and a walk through collections and references.
 slug: gcp-firestore-python
 category: cloud
 tags: GCP, python

--- a/apps/blog/blog/markdown/posts/gcp.md
+++ b/apps/blog/blog/markdown/posts/gcp.md
@@ -1,6 +1,8 @@
 ---
 title: "Project: GCP Deep Dive"
-summary: An ongoing in-depth exploration of Google Cloud Platform
+summary: An ongoing deep dive into Google Cloud Platform, with hands-on posts
+  covering Cloud Build, Cloud Storage website hosting, Container Registry, and
+  Firestore.
 slug: gcp
 tags: GCP
 category: projects

--- a/apps/blog/blog/markdown/posts/git-reference.md
+++ b/apps/blog/blog/markdown/posts/git-reference.md
@@ -1,6 +1,8 @@
 ---
 title: Git Reference Page
-summary: Deleting a file after it's been pushed to to a remote git repository
+summary: Practical Git recipes — renaming branches, rolling back a merge,
+  switching the commit editor to Vim, and scrubbing a file out of history with
+  filter-branch.
 slug: git reference
 tags: Git
 category: reference pages

--- a/apps/blog/blog/markdown/posts/git-reference.md
+++ b/apps/blog/blog/markdown/posts/git-reference.md
@@ -1,6 +1,6 @@
 ---
 title: Git Reference Page
-summary: Practical Git recipes — renaming branches, rolling back a merge,
+summary: Practical Git recipes for renaming branches, rolling back a merge,
   switching the commit editor to Vim, and scrubbing a file out of history with
   filter-branch.
 slug: git reference

--- a/apps/blog/blog/markdown/posts/github-pages.md
+++ b/apps/blog/blog/markdown/posts/github-pages.md
@@ -1,6 +1,8 @@
 ---
 title: "Github Pages: Basics"
-summary: Building a simple page for your Git project using GitHub Pages
+summary: Spinning up a GitHub Pages site from the docs folder on master, with
+  a custom domain via Cloudflare CNAME, a Jekyll theme, and Markdown-based
+  sub-pages.
 slug: github-pages
 category: development
 tags: Git

--- a/apps/blog/blog/markdown/posts/google-cloud-build.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-build.md
@@ -1,6 +1,8 @@
 ---
 title: "Google Cloud Build: Basics"
-summary: An introduction to the Google Cloud Build, showing how its used for this site.
+summary: Intro to Google Cloud Build with real cloudbuild.yaml examples — push
+  Docker images to GCR and rsync a static site to Cloud Storage on every Git
+  commit.
 slug: google-cloud-build
 tags: GCP,Docker,CI/CD
 category: cloud

--- a/apps/blog/blog/markdown/posts/google-cloud-build.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-build.md
@@ -1,8 +1,8 @@
 ---
 title: "Google Cloud Build: Basics"
-summary: Intro to Google Cloud Build with real cloudbuild.yaml examples — push
-  Docker images to GCR and rsync a static site to Cloud Storage on every Git
-  commit.
+summary: Intro to Google Cloud Build with real cloudbuild.yaml examples for
+  pushing Docker images to GCR and rsyncing a static site to Cloud Storage on
+  every Git commit.
 slug: google-cloud-build
 tags: GCP,Docker,CI/CD
 category: cloud

--- a/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
@@ -1,6 +1,8 @@
 ---
 title: "Google Cloud Storage: Website Hosting"
-summary: How to host a static website using Google Cloud Storage buckets.
+summary: Hosting a static site on Google Cloud Storage — Search Console domain
+  verification, bucket setup, a CNAME to c.storage.googleapis.com, and real
+  pricing numbers.
 slug: google-cloud-storage-website
 tags: GCP
 category: cloud

--- a/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
+++ b/apps/blog/blog/markdown/posts/google-cloud-storage-website.md
@@ -1,8 +1,8 @@
 ---
 title: "Google Cloud Storage: Website Hosting"
-summary: Hosting a static site on Google Cloud Storage — Search Console domain
-  verification, bucket setup, a CNAME to c.storage.googleapis.com, and real
-  pricing numbers.
+summary: Host a static site on Google Cloud Storage with Search Console
+  domain verification, bucket setup, a CNAME to c.storage.googleapis.com, and
+  real pricing numbers.
 slug: google-cloud-storage-website
 tags: GCP
 category: cloud

--- a/apps/blog/blog/markdown/posts/google-container-registry.md
+++ b/apps/blog/blog/markdown/posts/google-container-registry.md
@@ -1,8 +1,8 @@
 ---
 title: "Google Container Registry: Basics"
-summary: Getting started with Google Container Registry — why GCR beats a
-  self-hosted Docker registry, setting up service accounts, and Docker auth via
-  gcloud.
+summary: Getting started with Google Container Registry, covering why GCR
+  beats a self-hosted Docker registry, setting up service accounts, and Docker
+  auth via gcloud.
 slug: google-container-registry
 tags: GCP,Docker
 category: cloud

--- a/apps/blog/blog/markdown/posts/google-container-registry.md
+++ b/apps/blog/blog/markdown/posts/google-container-registry.md
@@ -1,6 +1,8 @@
 ---
 title: "Google Container Registry: Basics"
-summary: "An introduction to the Google Container Registry: pricing and how to store images."
+summary: Getting started with Google Container Registry — why GCR beats a
+  self-hosted Docker registry, setting up service accounts, and Docker auth via
+  gcloud.
 slug: google-container-registry
 tags: GCP,Docker
 category: cloud

--- a/apps/blog/blog/markdown/posts/linear-mcp.md
+++ b/apps/blog/blog/markdown/posts/linear-mcp.md
@@ -1,6 +1,8 @@
 ---
 title: "Linear MCP: Planning with Robots"
-summary: Connecting AI coding tools directly to Linear so AI can pull tasks in
+summary: Wiring Linear's official MCP server into Claude Code via OAuth, then
+  designing a nightly ideation agent that files Backlog suggestions gated by
+  issue status.
 slug: linear-mcp
 category: ai
 tags: Linear, MCP, Claude-Code, Cursor, AI

--- a/apps/blog/blog/markdown/posts/mac-fix-usb-drive.md
+++ b/apps/blog/blog/markdown/posts/mac-fix-usb-drive.md
@@ -1,6 +1,8 @@
 ---
 title: Fix shrunken USB drive after using as boot disk
-summary: How to fix formatting USB sticks after they shrink for burning .iso's to them.
+summary: Restoring a USB drive's full size on macOS after dd or Etcher shrank
+  it for a boot disk, using diskutil eraseDisk and, if needed, zeroing the
+  partition with dd.
 slug: mac-fix-usb-drive
 category: systems administration
 tags: Mac OS

--- a/apps/blog/blog/markdown/posts/mac-vlan-thunderbolt.md
+++ b/apps/blog/blog/markdown/posts/mac-vlan-thunderbolt.md
@@ -1,6 +1,8 @@
 ---
 title: VLAN Tagging Mac Thunderbolt NIC IP Traffic
-summary: Configuring the external Thunderbolt MAC NIC to encapsulate its traffic in a VLAN
+summary: Click-by-click steps for adding an 802.1Q VLAN tag to a Thunderbolt
+  Ethernet adapter on macOS so you can plug a MacBook into a switch's trunk
+  port for testing.
 slug: mac-vlan-thunderbolt
 category: systems administration
 tags: Mac OS

--- a/apps/blog/blog/markdown/posts/mermaid-markdown-support.md
+++ b/apps/blog/blog/markdown/posts/mermaid-markdown-support.md
@@ -1,6 +1,8 @@
 ---
 title: Mermaid Diagrams in Markdown
-summary: Rendering Mermaid diagrams alongside the existing markdown and grey matter pipeline.
+summary: Adding Mermaid diagram rendering to a Next.js blog via a custom remark
+  plugin, with syntax examples for flowcharts, sequence diagrams, and state
+  diagrams.
 slug: mermaid-markdown-support
 tags: markdown, mermaid, diagram, ai
 category: development

--- a/apps/blog/blog/markdown/posts/openclaw-linear-skill.md
+++ b/apps/blog/blog/markdown/posts/openclaw-linear-skill.md
@@ -1,7 +1,8 @@
 ---
 title: "Writing My Own OpenClaw Skill for Linear"
-summary: Building a custom Linear skill for OpenClaw instead
-  of trusting the public skill marketplace.
+summary: Writing an auditable Linear skill for OpenClaw after the ClawHavoc
+  attack poisoned ClawHub, using curl and Linear's GraphQL API instead of a
+  marketplace skill.
 slug: openclaw-linear-skill
 category: dev
 tags: openclaw, Linear, security, AI, self-hosted

--- a/apps/blog/blog/markdown/posts/openclaw-mvp.md
+++ b/apps/blog/blog/markdown/posts/openclaw-mvp.md
@@ -1,7 +1,8 @@
 ---
 title: "OpenClaw MVP"
-summary: Setting up OpenClaw as a self-hosted AI agent on
-  macOS, connected to Telegram.
+summary: Installing OpenClaw on macOS, picking a model between Gemini 2.5
+  Flash's free tier and paid Claude or GPT, and wiring it up to a Telegram bot
+  via BotFather.
 slug: openclaw-mvp
 category: dev
 tags: openclaw, telegram, linear, ai, self-hosted

--- a/apps/blog/blog/markdown/posts/openrouter-ai-tools.md
+++ b/apps/blog/blog/markdown/posts/openrouter-ai-tools.md
@@ -1,6 +1,8 @@
 ---
 title: "OpenRouter for Claude Code, OpenCode, and OpenClaw"
-summary: Configuring OpenRouter to be where all my tools go for tokens and making a custom MCP server for it
+summary: Routing Claude Code, OpenCode, and OpenClaw through one OpenRouter API
+  key for unified billing, swapping in Gemini via env vars, plus a custom MCP
+  server.
 slug: openrouter-ai-tools
 category: dev
 tags: openrouter, Claude-Code, opencode, openclaw, AI, mcp

--- a/apps/blog/blog/markdown/posts/openssl-csr-san.md
+++ b/apps/blog/blog/markdown/posts/openssl-csr-san.md
@@ -1,6 +1,8 @@
 ---
 title: Creating a CSR with a SAN - openssl
-summary: Certs aren't valid without SubjectAltName (SANs) now, openssl makes it hard
+summary: Fixing ERR_CERT_COMMON_NAME_INVALID by generating an openssl CSR with
+  Subject Alternative Names, using a reusable san.ini config file and openssl
+  req.
 slug: openssl-csr-san
 category: systems administration
 tags: https, openssl

--- a/apps/blog/blog/markdown/posts/openstack-aio-ka-metal.md
+++ b/apps/blog/blog/markdown/posts/openstack-aio-ka-metal.md
@@ -1,6 +1,7 @@
 ---
 title: Install Non-Prod OpenStack on a Physical Server
-summary: Installing all-in-one OpenStack with Kolla-Ansible metal as a test cloud
+summary: Step-by-step Kolla-Ansible install of OpenStack Rocky on a single Ubuntu 18.04
+  server with Keystone, Nova, Neutron, Cinder LVM, Heat, and Magnum.
 slug: openstack-aio-ka-metal
 category: cloud
 tags: OpenStack

--- a/apps/blog/blog/markdown/posts/openstack-aio-ka-vm.md
+++ b/apps/blog/blog/markdown/posts/openstack-aio-ka-vm.md
@@ -1,6 +1,7 @@
 ---
 title: Install OpenStack with Kolla-Ansible in a VM
-summary: Installing OpenStack on a cloud VM with Kolla-Ansible for dev and testing
+summary: Build a throwaway OpenStack Rocky dev cloud inside a single Ubuntu 18.04
+  VM using Kolla-Ansible, Cinder LVM, and a VLAN provider network.
 slug: openstack-aio-ka-vm
 category: cloud
 tags: OpenStack

--- a/apps/blog/blog/markdown/posts/openstack-ansible.md
+++ b/apps/blog/blog/markdown/posts/openstack-ansible.md
@@ -1,6 +1,7 @@
 ---
 title: Operating OpenStack from Ansible
-summary: Creating instances, volumes, and networks in OpenStack using Ansible
+summary: Automate OpenStack workloads with Ansible os_ modules. Covers auth, projects,
+  users, quotas, networks, volumes, and launching VMs on an existing cloud.
 slug: openstack-ansible
 category: cloud
 tags: OpenStack, Ansible

--- a/apps/blog/blog/markdown/posts/openstack-fix-cli.md
+++ b/apps/blog/blog/markdown/posts/openstack-fix-cli.md
@@ -1,6 +1,7 @@
 ---
 title: "OpenStack: Fixing the CLI (python2) error: No module named queue"
-summary: pip install python-openstack does not work without this fix
+summary: "Fix the broken python-openstackclient install on Ubuntu 18.04 by swapping
+  `import queue` for `from multiprocessing import Queue as queue` in the SDK files."
 slug: openstack-fix-cli
 category: cloud
 tags: OpenStack

--- a/apps/blog/blog/markdown/posts/openstack-kolla-custom-plugin.md
+++ b/apps/blog/blog/markdown/posts/openstack-kolla-custom-plugin.md
@@ -1,6 +1,7 @@
 ---
 title: Modifying OpenStack Kolla Docker Images
-summary: Creating a custom Cinder Docker image without modifying the Kolla code.
+summary: Add the Pure Storage Cinder plugin to a Kolla OpenStack image with a Jinja2
+  template override, keeping the upstream Kolla source untouched.
 slug: openstack-kolla-custom-plugin
 category: cloud
 tags: OpenStack

--- a/apps/blog/blog/markdown/posts/openstack.md
+++ b/apps/blog/blog/markdown/posts/openstack.md
@@ -1,6 +1,7 @@
 ---
 title: "Project: OpenStack Deep Dive"
-summary: An ongoing in-depth exploration of the various projects and features of OpenStack.
+summary: A deep-dive index of OpenStack posts covering Kolla-Ansible installs on metal
+  and VMs, custom Kolla images, Ansible automation, and why run a private cloud.
 slug: openstack
 tags: OpenStack
 category: projects

--- a/apps/blog/blog/markdown/posts/ops-cheatsheet.md
+++ b/apps/blog/blog/markdown/posts/ops-cheatsheet.md
@@ -1,6 +1,7 @@
 ---
 title: Operations Reference Page
-summary: Mini-posts and notes that are generally related to operations
+summary: Grab-bag of Linux ops recipes. tcpdump, vim find and replace, passwordless
+  sudo, loopback volumes, journalctl, bash exit traps, MTU tests, and more.
 slug: ops
 category: reference pages
 tags: Mac OS, Ubuntu, Vim, Docker, Ansible, Bash

--- a/apps/blog/blog/markdown/posts/pelican-dev-environment.md
+++ b/apps/blog/blog/markdown/posts/pelican-dev-environment.md
@@ -1,6 +1,7 @@
 ---
 title: Local Pelican Development Environment
-summary: How to set up a Docker-based local development environment for Pelican static sites.
+summary: Preview Pelican markdown changes live in a persistent Docker container with
+  content, config, and theme mounts plus auto-regeneration on save.
 slug: pelican-dev-environment
 category: development
 tags: Pelican, Docker

--- a/apps/blog/blog/markdown/posts/python-ceph.md
+++ b/apps/blog/blog/markdown/posts/python-ceph.md
@@ -1,6 +1,7 @@
 ---
 title: Python Ceph Examples
-summary: Some examples of using Ceph from Python with the rbd library
+summary: Use Ceph's rados and rbd Python libraries to check cluster health, list and
+  create pools, and manage RBD block-device images with real code samples.
 slug: python-ceph
 category: development
 tags: Python, Ceph

--- a/apps/blog/blog/markdown/posts/python-cheat-sheet.md
+++ b/apps/blog/blog/markdown/posts/python-cheat-sheet.md
@@ -1,6 +1,7 @@
 ---
 title: Python Reference Page
-summary: Useful code patterns, notes, and ideas about python code
+summary: Python snippets I reach for often. Pylint disable comments, list comprehensions,
+  Jinja2 templating, MySQL queries, stdin pipes, and file string replacement.
 slug: python
 category: reference pages
 tags: python

--- a/apps/blog/blog/markdown/posts/python-http-transfer.md
+++ b/apps/blog/blog/markdown/posts/python-http-transfer.md
@@ -1,6 +1,7 @@
 ---
 title: Transferring files to Windows through Python's SimpleHTTPServer
-summary: Using SimpleHTTPServer to transfer files to Windows without a file-share or SCP
+summary: Push a one-off file to a locked-down Windows box from Linux by hosting it
+  with `python -m SimpleHTTPServer` and grabbing it in Internet Explorer.
 slug: python-http-transfer
 category: systems administration
 tags: Python

--- a/apps/blog/blog/markdown/posts/python-pypi.md
+++ b/apps/blog/blog/markdown/posts/python-pypi.md
@@ -1,6 +1,7 @@
 ---
 title: Upload a Python Package to PyPi
-summary: Sharing a custom python package on PyPi so it can be pulled with pip
+summary: Publish a pip-installable Python package to PyPI. Walks through setup.py,
+  setup.cfg, a GitHub release for download_url, and uploading with twine.
 slug: python-pypi
 category: development
 tags: python,pypi

--- a/apps/blog/blog/markdown/posts/python-sql-json.md
+++ b/apps/blog/blog/markdown/posts/python-sql-json.md
@@ -1,6 +1,7 @@
 ---
 title: Working with JSON SQL values in Python
-summary: Using raw SQL queries to manage JSON values in databases
+summary: Pull a JSON blob out of a MariaDB column into a file, edit it, and write it
+  back using raw SQL in Python with the mysql-connector library.
 slug: python-raw-sql-json
 category: development
 tags: python

--- a/apps/blog/blog/markdown/posts/rhel-virtio-initrd.md
+++ b/apps/blog/blog/markdown/posts/rhel-virtio-initrd.md
@@ -1,6 +1,7 @@
 ---
 title: Adding Virtio drivers for KVM to RHEL's initrd
-summary: RHEL images won't boot on OpenStack without KVM's Virtio drivers
+summary: Fix a RHEL VM that drops to the dracut prompt after migrating to KVM or OpenStack
+  by chrooting in and injecting virtio drivers into the initrd with dracut.
 slug: rhel-virtio-initrd
 category: cloud
 tags: OpenStack

--- a/apps/blog/blog/markdown/posts/ubuntu-bionic-wifi.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-bionic-wifi.md
@@ -1,6 +1,7 @@
 ---
 title: Connecting Ubuntu 18.04 to WPA WiFi from CLI
-summary: Using the CLI on Ubuntu Server to connect a to a WPA wireless network.
+summary: Connect Ubuntu Server 18.04 to a WPA2 WiFi network from the command line
+  using wpa_supplicant, iwlist, and netplan, including offline package install steps.
 slug: ubuntu-bionic-wifi
 category: systems administration
 tags: ubuntu, WiFi

--- a/apps/blog/blog/markdown/posts/ubuntu-nfs-server.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-nfs-server.md
@@ -1,6 +1,7 @@
 ---
 title: Ubuntu NFS Server Setup
-summary: Installing, configuring, and testing NFS server on Ubuntu 18.04
+summary: Install and configure an NFS server on Ubuntu 18.04 with nfs-kernel-server,
+  set up /etc/exports for a subnet, apply with exportfs, and mount from a client.
 slug: ubuntu-nfs-server
 category: systems administration
 tags: ubuntu, NFS

--- a/apps/blog/blog/markdown/posts/ubuntu-trust-corporate-ca.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-trust-corporate-ca.md
@@ -1,6 +1,7 @@
 ---
 title: "Ubuntu: Blindly Trusting the Corporate CA"
-summary: Trusting a CA-signed certificate from a companies firewall on Ubuntu
+summary: Extract a corporate CA certificate with openssl s_client and install it
+  on Ubuntu via /usr/local/share/ca-certificates and update-ca-certificates.
 slug: ubuntu-trust-corporate-ca
 category: systems administration
 tags: Ubuntu, HTTPS

--- a/apps/blog/blog/markdown/posts/ubuntu-wifi-to-wired-router.md
+++ b/apps/blog/blog/markdown/posts/ubuntu-wifi-to-wired-router.md
@@ -1,6 +1,7 @@
 ---
 title: Creating a Wireless Router for Wired Servers With Ubuntu Server
-summary: Connecting wired servers, through a switch, to an ubuntu server with a wireless card.
+summary: Turn an Ubuntu Server into a WiFi-to-wired NAT gateway using netplan,
+  IP forwarding, and iptables MASQUERADE so switched servers can reach the internet.
 slug: ubuntu-wifi-to-wired-router
 tags: WiFi, Ubuntu
 category: systems administration

--- a/apps/blog/blog/markdown/posts/vim-spellcheck.md
+++ b/apps/blog/blog/markdown/posts/vim-spellcheck.md
@@ -1,6 +1,7 @@
 ---
 title: Vim Spell-Check
-summary: How to enable, disable, and use spell check in Vim (version >=7).
+summary: Enable Vim's built-in spell checker with :set spell spelllang=en_ca, jump
+  between misspellings with ]s and [s, and fix, add, or flag words using z=, zg, zw.
 slug: vim-spellcheck
 category: development
 tags: Vim

--- a/apps/blog/blog/markdown/posts/wiki-rag.md
+++ b/apps/blog/blog/markdown/posts/wiki-rag.md
@@ -1,7 +1,7 @@
 ---
 title: "RAG on the Bot-Wiki"
-summary: Building a FAISS retrieval pipeline over the wiki
-  using OpenRouter embeddings.
+summary: Build a tiny RAG pipeline over a 21-page wiki using FAISS flat index,
+  OpenRouter embeddings, and whole-page chunks enriched with frontmatter context.
 slug: wiki-rag
 category: ai
 tags: RAG, FAISS, OpenRouter, embeddings, Bot-Wiki, Python

--- a/apps/blog/blog/markdown/posts/windows-kvm-command-line.md
+++ b/apps/blog/blog/markdown/posts/windows-kvm-command-line.md
@@ -1,6 +1,7 @@
 ---
 title: Create Windows KVM VM from Command Line
-summary: Creating a Windows KVM VM without OpenStack using the command line on Ubuntu 18.04
+summary: Create a Windows KVM virtual machine on Ubuntu 18.04 from the command line
+  with qemu-kvm, libvirt, virt-install, and a netplan bridge. No OpenStack required.
 slug: windows-kvm-command-line
 category: systems administration
 tags: Ubuntu, KVM

--- a/apps/blog/blog/markdown/posts/windows-kvm-drivers.md
+++ b/apps/blog/blog/markdown/posts/windows-kvm-drivers.md
@@ -1,6 +1,7 @@
 ---
 title: Injecting KVM Drivers to Windows 10 for OpenStack
-summary: How to inject KVM drivers into a Windows 10 image for use in OpenStack Glance
+summary: Inject VirtIO KVM drivers (viostor, Balloon, NetKVM) into a Windows 10
+  VHDX image with Dism so it can boot on OpenStack Glance after qcow2 conversion.
 slug: windows-kvm-drivers
 category: cloud
 tags: OpenStack, Windows

--- a/apps/blog/blog/markdown/posts/writing-pelican-content.md
+++ b/apps/blog/blog/markdown/posts/writing-pelican-content.md
@@ -1,6 +1,7 @@
 ---
 title: Writing Blog Content for Pelican
-summary: Steps and examples for writing web content to be consumed by Pelican
+summary: Set up a Pelican static site project with pelicanconf.py, structure posts
+  and pages under content/, and write markdown with the metadata fields Pelican uses.
 slug: writing-pelican-content
 category: development
 tags: Pelican

--- a/apps/blog/blog/markdown/posts/x11-forwarding-ubuntu18.md
+++ b/apps/blog/blog/markdown/posts/x11-forwarding-ubuntu18.md
@@ -1,6 +1,7 @@
 ---
 title: Launching Chrome from a Remote Ubuntu Server over SSH
-summary: Launching chrome on a remote Ubuntu server using a local X11 graphics server
+summary: Run Chrome on a headless Ubuntu server and render it on a Mac with SSH
+  X11 forwarding, XQuartz, and ssh_config tweaks. No VNC, RDP, or desktop install.
 slug: x11-forwarding-ubuntu
 category: systems administration
 tags: remote access, Ubuntu, Chrome


### PR DESCRIPTION
## Summary

The seo-bot has been grinding through short meta descriptions one per night (#178 for packet-tracing-reference, #182 for ceph-reference). It identified 88 posts with summaries under 100 chars. At one-per-night, that's another 2+ months of bot runs doing the exact same thing.

This does them all in one pass: 66 remaining posts rewritten to 140-160 character summaries (the Google SERP snippet sweet spot).

## What changed

For each post, the agent read the actual post body and wrote a specific, concrete summary covering the real tools, commands, and techniques — not generic filler. Old summaries averaged ~65 chars; new ones average ~150 chars.

Example:
- Before: \`Ceph reference page\` (19 chars)
- After: \`Quick reference for Ceph storage commands: pool replica management, RBD volume create/map/delete, snapshot rollback, and exporting RBD images to files.\` (151 chars)

## Scope

- 66 files changed
- Only \`summary:\` field modified
- No slug, title, keywords, tags, or body changes
- Blog build verified clean (336 pages generated)

## Test plan

- [x] Blog builds cleanly
- [x] Verified 0 posts remain with summary ≤ 100 chars
- [ ] Spot-check a few posts on GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined summaries for 50+ blog posts site-wide, replacing generic descriptions with specific, detailed overviews. Updated summaries now clearly indicate article scope, highlight technologies and approaches covered, and describe concrete outcomes. These improvements enhance content discoverability and help readers more easily find posts relevant to their interests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->