### PR TITLE
llm-client: halve-on-compact + real token usage

### DIFF
--- a/apps/llm-client/README.md
+++ b/apps/llm-client/README.md
@@ -58,14 +58,19 @@ context that shouldn't repeat.
   (`min(1024, 50% of per-slot)`, configurable in Settings).
 - **Tail-drop truncation** — oldest messages are dropped first. The
   seed-augmented first message is always kept.
-- **Rolling compaction** (on by default) — when context hits 80%, the
-  oldest 50% of non-seed messages are summarized into a persistent
-  "Story so far" that grows across compaction events. Editable in the
-  chat transcript. Summary budget capped at a configurable % (default 25%).
-  If the summary overshoots its budget, retries up to 2x with a "shorten"
-  prompt. After compaction, if reply room would be below the min reply
-  tokens threshold (default 500, configurable), the summary is trimmed
-  to guarantee the model has room to respond.
+- **Rolling compaction** (on by default) — when context hits 80%, older
+  messages are summarized into a persistent "Story so far" that grows
+  across compaction events. Editable in the chat transcript. Each run
+  **targets half of the current context usage**: drops enough oldest
+  messages and sizes the summary budget so the rebuilt request lands
+  near 50% of what it was. Halving again on the next run keeps context
+  from monotonically creeping up. If the summary overshoots its budget,
+  the summarizer retries up to 2x with a "shorten" prompt. After
+  compaction, if reply room would be below the min reply tokens
+  threshold (default 500, configurable), the summary is trimmed to
+  guarantee the model has room to respond.
+- **Manual compact** — click the `compact` link beside the context meter
+  to halve the current context usage on demand.
 - **Context meter** — bottom-right shows live `X% ctx` usage. Amber at
   80%, red at 100%. "compacting..." indicator during summarization.
 - **Context override** — cap per-slot tokens in Settings for testing or
@@ -126,7 +131,7 @@ Full-pane settings (replaces chat area, sidebar stays). Sections:
 
 - **Prompts** — system prompt, seed prompt (text or file picker)
 - **Model** — temperature (0-2), context override, reply budget, min reply tokens
-- **Behavior** — auto-summarize + summary budget slider
+- **Behavior** — auto-summarize toggle (halves context on each compaction)
 - **Post-processing** — duplicate retry, choice extraction, colour support
   + editable colour prompt
 

--- a/apps/llm-client/package.json
+++ b/apps/llm-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-client",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/llm-client/src/components/chat/chat-pane.tsx
+++ b/apps/llm-client/src/components/chat/chat-pane.tsx
@@ -9,6 +9,7 @@ import {
   computeInputBudget,
   computeReplyBudget,
   effectiveMaxTokens,
+  planCompaction,
   previewContext,
 } from "@/lib/context-manager";
 import { estimateTokens } from "@/lib/tokens";
@@ -48,7 +49,7 @@ export function ChatPane() {
   const contextOverride = useSettingsStore((s) => s.contextOverride);
   const replyBudgetOverride = useSettingsStore((s) => s.replyBudgetOverride);
   const autoSummarize = useSettingsStore((s) => s.autoSummarize);
-  const summaryBudgetPct = useSettingsStore((s) => s.summaryBudgetPct);
+  const showTokenCount = useSettingsStore((s) => s.showTokenCount);
   const deduplicateRetry = useSettingsStore((s) => s.deduplicateRetry);
   const temperature = useSettingsStore((s) => s.temperature);
   const colorSupport = useSettingsStore((s) => s.colorSupport);
@@ -103,7 +104,6 @@ export function ChatPane() {
       systemPrompt: effectiveSystemPrompt,
       seedPrompt: effectiveSeedPrompt,
       summary: chat?.summary,
-      summaryBudgetPct,
     });
   }, [
     chat?.messages,
@@ -112,8 +112,25 @@ export function ChatPane() {
     inputBudget,
     effectiveSystemPrompt,
     effectiveSeedPrompt,
-    summaryBudgetPct,
   ]);
+
+  const lastUsage = useMemo(() => {
+    const msgs = chat?.messages ?? [];
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      const m = msgs[i];
+      if (
+        m.role === "assistant" &&
+        typeof m.promptTokens === "number" &&
+        typeof m.completionTokens === "number"
+      ) {
+        return {
+          promptTokens: m.promptTokens,
+          completionTokens: m.completionTokens,
+        };
+      }
+    }
+    return null;
+  }, [chat?.messages]);
 
   const streamingMessageId = useMemo(() => {
     if (!chat || !streaming || streaming.chatId !== chat.id) return null;
@@ -132,6 +149,111 @@ export function ChatPane() {
     [activeChatId, setSummary],
   );
 
+  // Core compaction routine: plan → summarize → (optionally) trim to protect
+  // minReplyTokens. Returns the summary that was written (or null on no-op).
+  const runCompaction = useCallback(
+    async (chatId: string, historyForRequest: ChatMessage[]): Promise<string | null> => {
+      const currentSummary =
+        useChatStore.getState().chats[chatId]?.summary || "";
+
+      const plan = planCompaction(historyForRequest, {
+        inputBudget,
+        systemPrompt: effectiveSystemPrompt,
+        seedPrompt: effectiveSeedPrompt,
+        existingSummary: currentSummary,
+      });
+
+      if (plan.messagesToCompact.length === 0) {
+        log.info("runCompaction: nothing to compact (already at/under target)");
+        return null;
+      }
+
+      log.info(
+        `runCompaction: compacting ${plan.messagesToCompact.length} messages, budget=${plan.summaryTokenBudget}, target=${plan.targetTokens}`,
+      );
+      const newSummary = await summarizeMessages(plan.messagesToCompact, {
+        endpoint,
+        existingSummary: currentSummary || undefined,
+        maxTokens: plan.summaryTokenBudget,
+        tokenBudget: plan.summaryTokenBudget,
+      });
+      if (!newSummary) {
+        log.warn("runCompaction: summarizer returned null");
+        return null;
+      }
+
+      setSummary(chatId, newSummary);
+
+      // Remove the compacted messages from the chat — they've been folded
+      // into the summary, so keeping them in history would double-count.
+      if (plan.compactThroughIndex >= 1) {
+        useChatStore
+          .getState()
+          .dropMessagesInRange(chatId, 1, plan.compactThroughIndex);
+        log.info(
+          `runCompaction: removed history[1..${plan.compactThroughIndex}] from chat`,
+        );
+      }
+
+      // Safety: if the post-compaction build leaves less than minReplyTokens
+      // of reply room, trim the summary so the model can still answer.
+      const latestMessages =
+        useChatStore.getState().chats[chatId]?.messages ?? [];
+      const build = buildRequestMessages(
+        latestMessages.map((m) => ({ role: m.role, content: m.content })),
+        {
+          inputBudget,
+          systemPrompt: effectiveSystemPrompt,
+          seedPrompt: effectiveSeedPrompt,
+          summary: newSummary,
+        },
+      );
+      const usedAfter = estimateTokens(
+        build.messages.map((m) => m.content).join(""),
+      );
+      const replyRoom = effectiveMaxTokens(replyBudget, perSlot, usedAfter);
+      if (replyRoom < minReplyTokens) {
+        const trimmed = newSummary.slice(
+          0,
+          Math.floor(newSummary.length * 0.5),
+        );
+        log.warn(
+          `runCompaction: reply room ${replyRoom} < ${minReplyTokens}, trimming summary to ${trimmed.length} chars`,
+        );
+        setSummary(chatId, trimmed);
+        return trimmed;
+      }
+
+      return newSummary;
+    },
+    [
+      effectiveSeedPrompt,
+      effectiveSystemPrompt,
+      endpoint,
+      inputBudget,
+      minReplyTokens,
+      perSlot,
+      replyBudget,
+      setSummary,
+    ],
+  );
+
+  const handleCompact = useCallback(async () => {
+    if (!activeChatId || compacting || streaming) return;
+    const messages = useChatStore.getState().chats[activeChatId]?.messages;
+    if (!messages || messages.length === 0) return;
+    const historyForRequest = messages.map((m) => ({
+      role: m.role,
+      content: m.content,
+    }));
+    setCompacting(true);
+    try {
+      await runCompaction(activeChatId, historyForRequest);
+    } finally {
+      setCompacting(false);
+    }
+  }, [activeChatId, compacting, runCompaction, streaming]);
+
   const doSend = useCallback(
     async (chatId: string, historyForRequest: ChatMessage[], tempOverride?: number) => {
       // Cancel any in-flight color pass from a previous turn
@@ -140,78 +262,55 @@ export function ChatPane() {
       const currentSummary =
         useChatStore.getState().chats[chatId]?.summary || "";
 
-      let buildResult = buildRequestMessages(historyForRequest, {
+      let activeHistory = historyForRequest;
+      let buildResult = buildRequestMessages(activeHistory, {
         inputBudget,
         systemPrompt: effectiveSystemPrompt,
         seedPrompt: effectiveSeedPrompt,
         summary: currentSummary,
-        summaryBudgetPct,
       });
 
-      log.info(`doSend: chatId=${chatId} historyLen=${historyForRequest.length} currentSummaryLen=${currentSummary.length}`);
+      log.info(`doSend: chatId=${chatId} historyLen=${activeHistory.length} currentSummaryLen=${currentSummary.length}`);
 
+      const rawTotalTokens = estimateTokens(
+        activeHistory.map((m) => m.content).join(""),
+      );
       const shouldCompact =
         autoSummarize &&
         (buildResult.truncated ||
-          (buildResult.droppedMessages.length === 0 &&
-            historyForRequest.length > 2 &&
-            estimateTokens(
-              historyForRequest.map((m) => m.content).join(""),
-            ) >
-              inputBudget * 0.8));
+          (activeHistory.length > 2 &&
+            rawTotalTokens > inputBudget * 0.8));
 
       log.info(`doSend: shouldCompact=${shouldCompact} truncated=${buildResult.truncated} droppedMsgs=${buildResult.droppedMessages.length}`);
       if (shouldCompact) {
         log.info(`doSend: compaction triggered`);
         setCompacting(true);
-        let messagesToCompact = buildResult.droppedMessages;
-        if (messagesToCompact.length === 0 && historyForRequest.length > 2) {
-          const half = Math.ceil((historyForRequest.length - 1) / 2);
-          messagesToCompact = historyForRequest.slice(1, 1 + half);
-        }
-
-        log.info(`doSend: compacting ${messagesToCompact.length} messages`);
-        if (messagesToCompact.length > 0) {
-          const summaryTokenBudget = Math.floor(
-            (inputBudget * summaryBudgetPct) / 100,
-          );
-          const newSummary = await summarizeMessages(messagesToCompact, {
-            endpoint,
-            existingSummary: currentSummary || undefined,
-            maxTokens: summaryTokenBudget,
-            tokenBudget: summaryTokenBudget,
-          });
-          if (newSummary) {
-            log.info(`doSend: summary updated (${newSummary.length} chars)`);
-            setSummary(chatId, newSummary);
-            buildResult = buildRequestMessages(historyForRequest, {
-              inputBudget,
-              systemPrompt: effectiveSystemPrompt,
-              seedPrompt: effectiveSeedPrompt,
-              summary: newSummary,
-              summaryBudgetPct,
-            });
-
-            const usedAfter = estimateTokens(
-              buildResult.messages.map((m) => m.content).join(""),
-            );
-            const replyRoom = effectiveMaxTokens(replyBudget, perSlot, usedAfter);
-            if (replyRoom < minReplyTokens) {
-              const trimTarget = Math.floor(newSummary.length * 0.5);
-              const trimmed = newSummary.slice(0, trimTarget);
-              log.warn(`doSend: reply room only ${replyRoom} tokens after compaction, trimming summary from ${newSummary.length} to ${trimmed.length} chars`);
-              setSummary(chatId, trimmed);
-              buildResult = buildRequestMessages(historyForRequest, {
-                inputBudget,
-                systemPrompt: effectiveSystemPrompt,
-                seedPrompt: effectiveSeedPrompt,
-                summary: trimmed,
-                summaryBudgetPct,
-              });
-            }
-          }
-        }
+        const updated = await runCompaction(chatId, activeHistory);
         setCompacting(false);
+        if (updated !== null) {
+          // runCompaction removed the compacted messages from the store and
+          // wrote a new summary. Refresh our working history from the store
+          // (skipping the trailing empty assistant placeholder appended by
+          // handleSend so we don't send it as an input message).
+          const storeMsgs =
+            useChatStore.getState().chats[chatId]?.messages ?? [];
+          const trailing = storeMsgs[storeMsgs.length - 1];
+          const usable =
+            trailing?.role === "assistant" && trailing.content === ""
+              ? storeMsgs.slice(0, -1)
+              : storeMsgs;
+          activeHistory = usable.map((m) => ({
+            role: m.role,
+            content: m.content,
+          }));
+          const latest = useChatStore.getState().chats[chatId]?.summary ?? "";
+          buildResult = buildRequestMessages(activeHistory, {
+            inputBudget,
+            systemPrompt: effectiveSystemPrompt,
+            seedPrompt: effectiveSeedPrompt,
+            summary: latest,
+          });
+        }
       }
 
       const requestMessages = buildResult.messages;
@@ -229,15 +328,33 @@ export function ChatPane() {
         const maxTok = effectiveMaxTokens(replyBudget, perSlot, usedInput);
         log.info(`runStream: replyBudget=${replyBudget} usedInput≈${usedInput} effectiveMax=${maxTok}`);
         let accumulated = "";
-        for await (const delta of streamChat({
+        for await (const event of streamChat({
           endpoint,
           messages: msgs,
           signal: controller.signal,
           maxTokens: maxTok,
           temperature: streamTempOverride ?? baseTemp,
         })) {
-          accumulated += delta;
-          appendToLastMessage(chatId, delta);
+          if (event.type === "delta") {
+            accumulated += event.content;
+            appendToLastMessage(chatId, event.content);
+          } else if (event.type === "usage") {
+            log.info(
+              `runStream: real usage prompt=${event.usage.promptTokens} completion=${event.usage.completionTokens} (estInput=${usedInput})`,
+            );
+            const chat = useChatStore.getState().chats[chatId];
+            const last = chat?.messages[chat.messages.length - 1];
+            if (last && last.role === "assistant") {
+              useChatStore
+                .getState()
+                .setMessageUsage(
+                  chatId,
+                  last.id,
+                  event.usage.promptTokens,
+                  event.usage.completionTokens,
+                );
+            }
+          }
         }
         return accumulated;
       };
@@ -257,7 +374,7 @@ export function ChatPane() {
 
         // Dedup check
         if (deduplicateRetry && fullResponse) {
-          const priorMessages = historyForRequest.map((m) => ({
+          const priorMessages = activeHistory.map((m) => ({
             role: m.role,
             content: m.content,
           }));
@@ -401,9 +518,10 @@ export function ChatPane() {
       effectiveSystemPrompt,
       endpoint,
       inputBudget,
-      setSummary,
+      perSlot,
+      replyBudget,
+      runCompaction,
       setStreaming,
-      summaryBudgetPct,
       temperature,
     ],
   );
@@ -531,7 +649,7 @@ export function ChatPane() {
             {chat ? chat.title : "llm-client"}
           </h1>
         </div>
-        {chat && preview.droppedCount > 0 && (
+        {chat && (chat.summary || preview.droppedCount > 0) && (
           <SummaryPanel
             summary={chat.summary ?? ""}
             onSummaryChange={handleSummaryChange}
@@ -550,6 +668,7 @@ export function ChatPane() {
           onRetry={handleRetry}
           onRegen={handleRegen}
           scrollTrigger={activeChoices.length + (generatingChoices ? 1 : 0) + (colorizing ? 1 : 0)}
+          showTokenCount={showTokenCount}
         />
       ) : (
         <div className="flex-1 overflow-y-auto">
@@ -591,6 +710,15 @@ export function ChatPane() {
           usedPercent={preview.usedPercent}
           truncated={preview.truncated}
           compacting={compacting}
+          onCompact={handleCompact}
+          compactDisabled={
+            !chat ||
+            chat.messages.length < 2 ||
+            Boolean(isStreaming) ||
+            compacting
+          }
+          lastRealPromptTokens={lastUsage?.promptTokens}
+          lastRealCompletionTokens={lastUsage?.completionTokens}
         />
       )}
     </section>

--- a/apps/llm-client/src/components/chat/chat-pane.tsx
+++ b/apps/llm-client/src/components/chat/chat-pane.tsx
@@ -285,8 +285,12 @@ export function ChatPane() {
       if (shouldCompact) {
         log.info(`doSend: compaction triggered`);
         setCompacting(true);
-        const updated = await runCompaction(chatId, activeHistory);
-        setCompacting(false);
+        let updated: string | null = null;
+        try {
+          updated = await runCompaction(chatId, activeHistory);
+        } finally {
+          setCompacting(false);
+        }
         if (updated !== null) {
           // runCompaction removed the compacted messages from the store and
           // wrote a new summary. Refresh our working history from the store
@@ -342,8 +346,9 @@ export function ChatPane() {
             log.info(
               `runStream: real usage prompt=${event.usage.promptTokens} completion=${event.usage.completionTokens} (estInput=${usedInput})`,
             );
-            const chat = useChatStore.getState().chats[chatId];
-            const last = chat?.messages[chat.messages.length - 1];
+            const snapshot = useChatStore.getState().chats[chatId];
+            const last =
+              snapshot?.messages[snapshot.messages.length - 1];
             if (last && last.role === "assistant") {
               useChatStore
                 .getState()

--- a/apps/llm-client/src/components/chat/composer.tsx
+++ b/apps/llm-client/src/components/chat/composer.tsx
@@ -18,6 +18,12 @@ interface ComposerProps {
   usedPercent: number;
   truncated: boolean;
   compacting?: boolean;
+  onCompact?: () => void;
+  compactDisabled?: boolean;
+  /** Real prompt_tokens from the last completed request, if known. */
+  lastRealPromptTokens?: number;
+  /** Real completion_tokens from the last completed request, if known. */
+  lastRealCompletionTokens?: number;
 }
 
 export function Composer({
@@ -32,6 +38,10 @@ export function Composer({
   usedPercent,
   truncated,
   compacting,
+  onCompact,
+  compactDisabled,
+  lastRealPromptTokens,
+  lastRealCompletionTokens,
 }: ComposerProps) {
   const serverType = useSettingsStore((s) => s.serverType);
   const endpoint = useSettingsStore((s) => s.endpoint);
@@ -124,19 +134,42 @@ export function Composer({
             : `${endpoint.replace(/^https?:\/\//, "")}/${modelId}`}
         </p>
         <div className="flex items-center gap-3">
-          {compacting && (
+          {compacting ? (
             <span
               className="animate-pulse text-amber-500"
               data-testid="compacting-indicator"
             >
               compacting…
             </span>
+          ) : (
+            onCompact && (
+              <button
+                type="button"
+                onClick={onCompact}
+                disabled={compactDisabled}
+                className={cn(
+                  "underline-offset-2 transition-colors",
+                  compactDisabled
+                    ? "cursor-not-allowed text-muted-foreground/40"
+                    : "text-muted-foreground hover:text-foreground hover:underline",
+                )}
+                data-testid="compact-link"
+                title="Summarize older messages to shrink context to the Compaction target"
+              >
+                compact
+              </button>
+            )
           )}
         </div>
         <p
           className={cn("font-mono", meterColor)}
           data-testid="context-meter"
-          title={`${usedTokens.toLocaleString()} / ${inputBudget.toLocaleString()} tokens`}
+          title={
+            `${usedTokens.toLocaleString()} / ${inputBudget.toLocaleString()} tokens (estimate)` +
+            (typeof lastRealPromptTokens === "number"
+              ? `\nLast request (real): prompt=${lastRealPromptTokens.toLocaleString()}, completion=${(lastRealCompletionTokens ?? 0).toLocaleString()}`
+              : "")
+          }
         >
           {truncated ? "⚠ " : ""}
           {usedPercent}% ctx

--- a/apps/llm-client/src/components/chat/composer.tsx
+++ b/apps/llm-client/src/components/chat/composer.tsx
@@ -154,7 +154,7 @@ export function Composer({
                     : "text-muted-foreground hover:text-foreground hover:underline",
                 )}
                 data-testid="compact-link"
-                title="Summarize older messages to shrink context to the Compaction target"
+                title="Summarize older messages and halve the current context usage"
               >
                 compact
               </button>

--- a/apps/llm-client/src/components/chat/message-bubble.tsx
+++ b/apps/llm-client/src/components/chat/message-bubble.tsx
@@ -8,6 +8,7 @@ import { RefreshCw } from "lucide-react";
 import { processColors } from "@/lib/colors";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { estimateTokens } from "@/lib/tokens";
 import type { ChatRole } from "@/lib/context-manager";
 
 interface MessageBubbleProps {
@@ -17,6 +18,9 @@ interface MessageBubbleProps {
   hasError?: boolean;
   onRetry?: () => void;
   onRegen?: () => void;
+  showTokenCount?: boolean;
+  /** Real completion_tokens for assistant messages, when known. */
+  completionTokens?: number;
 }
 
 export function MessageBubble({
@@ -26,9 +30,23 @@ export function MessageBubble({
   hasError,
   onRetry,
   onRegen,
+  showTokenCount,
+  completionTokens,
 }: MessageBubbleProps) {
   const isUser = role === "user";
   const label = isUser ? "User:" : role === "assistant" ? "Bot:" : "System:";
+
+  const hasRealCount =
+    !isUser && typeof completionTokens === "number" && !streaming;
+  const tokenCount = hasRealCount
+    ? completionTokens
+    : streaming
+      ? null
+      : estimateTokens(content || "");
+  const tokenLabel =
+    tokenCount === null
+      ? null
+      : `${tokenCount} tok${hasRealCount ? "" : "~"}`;
 
   return (
     <div
@@ -75,6 +93,19 @@ export function MessageBubble({
             </>
           )}
         </div>
+        {showTokenCount && tokenLabel && (
+          <span
+            className="px-1 font-mono text-[10px] text-muted-foreground/60"
+            title={
+              hasRealCount
+                ? `Server-reported completion tokens`
+                : `Local estimate (server didn't report usage)`
+            }
+            data-testid={`msg-tokens-${role}`}
+          >
+            {tokenLabel}
+          </span>
+        )}
         {!isUser && !streaming && (
           <div className="mt-1 flex gap-1">
             {hasError && onRetry && (

--- a/apps/llm-client/src/components/chat/message-list.tsx
+++ b/apps/llm-client/src/components/chat/message-list.tsx
@@ -12,6 +12,7 @@ interface MessageListProps {
   onRetry?: () => void;
   onRegen?: (messageId: string) => void;
   scrollTrigger?: number;
+  showTokenCount?: boolean;
 }
 
 export function MessageList({
@@ -22,6 +23,7 @@ export function MessageList({
   onRetry,
   onRegen,
   scrollTrigger,
+  showTokenCount,
 }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const isPinnedRef = useRef(true);
@@ -65,6 +67,8 @@ export function MessageList({
             role={messages[0].role}
             content={messages[0].content}
             streaming={messages[0].id === streamingMessageId}
+            showTokenCount={showTokenCount}
+            completionTokens={messages[0].completionTokens}
           />
         )}
 
@@ -84,6 +88,8 @@ export function MessageList({
                   ? () => onRegen(msg.id)
                   : undefined
               }
+              showTokenCount={showTokenCount}
+              completionTokens={msg.completionTokens}
             />
           );
         })}

--- a/apps/llm-client/src/components/settings/settings-pane.tsx
+++ b/apps/llm-client/src/components/settings/settings-pane.tsx
@@ -49,7 +49,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
   const storedReplyBudget = useSettingsStore((s) => s.replyBudgetOverride);
   const storedMinReply = useSettingsStore((s) => s.minReplyTokens);
   const storedAutoSummarize = useSettingsStore((s) => s.autoSummarize);
-  const storedSummaryBudget = useSettingsStore((s) => s.summaryBudgetPct);
+  const storedShowTokenCount = useSettingsStore((s) => s.showTokenCount);
   const storedDedupRetry = useSettingsStore((s) => s.deduplicateRetry);
   const storedTemperature = useSettingsStore((s) => s.temperature);
   const setSystemPrompt = useSettingsStore((s) => s.setSystemPrompt);
@@ -58,7 +58,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
   const setReplyBudgetOverride = useSettingsStore((s) => s.setReplyBudgetOverride);
   const setMinReplyTokens = useSettingsStore((s) => s.setMinReplyTokens);
   const setAutoSummarize = useSettingsStore((s) => s.setAutoSummarize);
-  const setSummaryBudgetPct = useSettingsStore((s) => s.setSummaryBudgetPct);
+  const setShowTokenCount = useSettingsStore((s) => s.setShowTokenCount);
   const storedChoiceButtons = useSettingsStore((s) => s.choiceButtons);
   const storedChoicePrompt = useSettingsStore((s) => s.choicePrompt);
   const storedChoiceCount = useSettingsStore((s) => s.choiceCount);
@@ -93,8 +93,9 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
   const [localMinReply, setLocalMinReply] = useState(String(storedMinReply));
   const [localAutoSummarize, setLocalAutoSummarize] =
     useState(storedAutoSummarize);
-  const [localSummaryBudget, setLocalSummaryBudget] =
-    useState(storedSummaryBudget);
+  const [localShowTokenCount, setLocalShowTokenCount] = useState(
+    storedShowTokenCount,
+  );
   const [localDedupRetry, setLocalDedupRetry] = useState(storedDedupRetry);
   const [localTemp, setLocalTemp] = useState(String(storedTemperature));
   const [localChoiceButtons, setLocalChoiceButtons] = useState(storedChoiceButtons);
@@ -128,7 +129,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
     setReplyBudgetStr(storedReplyBudget === null ? "" : String(storedReplyBudget));
     setLocalMinReply(String(storedMinReply));
     setLocalAutoSummarize(storedAutoSummarize);
-    setLocalSummaryBudget(storedSummaryBudget);
+    setLocalShowTokenCount(storedShowTokenCount);
     setLocalDedupRetry(storedDedupRetry);
     setLocalTemp(String(storedTemperature));
     setLocalChoiceButtons(storedChoiceButtons);
@@ -137,7 +138,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
     setLocalDisableTextInput(storedDisableTextInput);
     setLocalColorSupport(storedColorSupport);
     setLocalColorColors(storedColorColors);
-  }, [storedSp, storedSpSrc, storedSpFile, storedSeed, storedSeedSrc, storedSeedFile, storedCtxOvr, storedReplyBudget, storedMinReply, storedAutoSummarize, storedSummaryBudget, storedDedupRetry, storedTemperature, storedChoiceButtons, storedChoicePrompt, storedChoiceCount, storedDisableTextInput, storedColorSupport, storedColorColors]);
+  }, [storedSp, storedSpSrc, storedSpFile, storedSeed, storedSeedSrc, storedSeedFile, storedCtxOvr, storedReplyBudget, storedMinReply, storedAutoSummarize, storedShowTokenCount, storedDedupRetry, storedTemperature, storedChoiceButtons, storedChoicePrompt, storedChoiceCount, storedDisableTextInput, storedColorSupport, storedColorColors]);
 
   const serverMax = perSlotCtx(serverInfo);
 
@@ -214,7 +215,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
     setTemperature(parsedTemp);
 
     setAutoSummarize(localAutoSummarize);
-    setSummaryBudgetPct(localSummaryBudget);
+    setShowTokenCount(localShowTokenCount);
     setDeduplicateRetry(localDedupRetry);
     setChoiceButtons(localChoiceButtons);
     setChoicePrompt(localChoicePrompt);
@@ -241,7 +242,7 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
       saveRef.current();
     }, 1000);
     return () => clearTimeout(autoSaveTimer.current);
-  }, [spSrc, spText, spFile, seedSrc, seedText, seedFile, overrideStr, replyBudgetStr, localMinReply, localAutoSummarize, localSummaryBudget, localDedupRetry, localTemp, localChoiceButtons, localChoicePrompt, localChoiceCount, localDisableTextInput, localColorSupport, localColorColors]);
+  }, [spSrc, spText, spFile, seedSrc, seedText, seedFile, overrideStr, replyBudgetStr, localMinReply, localAutoSummarize, localShowTokenCount, localDedupRetry, localTemp, localChoiceButtons, localChoicePrompt, localChoiceCount, localDisableTextInput, localColorSupport, localColorColors]);
 
   return (
     <section className="flex h-dvh flex-1 flex-col bg-background">
@@ -429,47 +430,42 @@ export function SettingsPane({ onClose }: SettingsPaneProps) {
               Behavior
             </h2>
 
-            <div className="rounded-md border border-border px-3 py-2.5">
-              <label className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-sm font-medium">Auto-summarize</div>
-                  <div className="text-[11px] text-muted-foreground">
-                    When old messages are dropped, generate a rolling "Story
-                    so far" summary. Editable in the chat transcript.
-                  </div>
+            <label className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2.5">
+              <div>
+                <div className="text-sm font-medium">Auto-summarize</div>
+                <div className="text-[11px] text-muted-foreground">
+                  When context hits 80%, fold older messages into a rolling
+                  "Story so far" summary, targeting half the current usage.
+                  Editable in the chat transcript. You can also trigger this
+                  manually via the `compact` link by the context meter.
                 </div>
-                <input
-                  type="checkbox"
-                  checked={localAutoSummarize}
-                  onChange={(e) => setLocalAutoSummarize(e.target.checked)}
-                  className="h-4 w-4 accent-primary"
-                  data-testid="toggle-auto-summarize"
-                />
-              </label>
-              {localAutoSummarize && (
-                <div className="mt-3 flex items-center gap-3 border-t border-border/50 pt-3">
-                  <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
-                    Summary budget
-                    <HintIcon text="Max % of the context window the 'Story so far' summary can use. Higher = more memory of old conversation but less room for recent messages. Lower = more room for recent turns but the summary gets truncated." />
-                  </span>
-                  <input
-                    type="range"
-                    min="5"
-                    max="50"
-                    step="5"
-                    value={localSummaryBudget}
-                    onChange={(e) =>
-                      setLocalSummaryBudget(parseInt(e.target.value, 10))
-                    }
-                    className="flex-1"
-                    data-testid="summary-budget-slider"
-                  />
-                  <span className="w-10 text-right font-mono text-xs text-muted-foreground">
-                    {localSummaryBudget}%
-                  </span>
+              </div>
+              <input
+                type="checkbox"
+                checked={localAutoSummarize}
+                onChange={(e) => setLocalAutoSummarize(e.target.checked)}
+                className="h-4 w-4 accent-primary"
+                data-testid="toggle-auto-summarize"
+              />
+            </label>
+
+            <label className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2.5">
+              <div>
+                <div className="text-sm font-medium">Show token count</div>
+                <div className="text-[11px] text-muted-foreground">
+                  Display a small "N tok" label under each message. Uses the
+                  server's real `usage` counts when available, falls back to
+                  local estimates otherwise.
                 </div>
-              )}
-            </div>
+              </div>
+              <input
+                type="checkbox"
+                checked={localShowTokenCount}
+                onChange={(e) => setLocalShowTokenCount(e.target.checked)}
+                className="h-4 w-4 accent-primary"
+                data-testid="toggle-show-token-count"
+              />
+            </label>
           </section>
 
           {/* Post-processing */}

--- a/apps/llm-client/src/lib/colorize-pass.ts
+++ b/apps/llm-client/src/lib/colorize-pass.ts
@@ -61,8 +61,14 @@ export async function colorizeResponse(
 
       const json = (await res.json()) as {
         choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
       };
       const content = json.choices?.[0]?.message?.content?.trim() ?? "";
+      if (json.usage) {
+        log.info(
+          `colorize(${code}): usage prompt=${json.usage.prompt_tokens} completion=${json.usage.completion_tokens}`,
+        );
+      }
 
       log.exchange(`exchange:colorize-${code}`, {
         messages: [

--- a/apps/llm-client/src/lib/context-manager.test.ts
+++ b/apps/llm-client/src/lib/context-manager.test.ts
@@ -260,7 +260,12 @@ describe("planCompaction", () => {
   it("estimated usage after compaction is ≤ target", () => {
     const history = makeHistory(40, (i) => `msg ${i} ` + "x".repeat(100));
     const plan = planCompaction(history, { inputBudget: 8000 });
-    expect(plan.estimatedUsedAfter).toBeLessThanOrEqual(plan.targetTokens + 8);
+    // Allow up to one kept message worth of overshoot — the even-count
+    // invariant can spare one message back into history.
+    const tolerance = Math.max(100, Math.floor(plan.targetTokens * 0.1));
+    expect(plan.estimatedUsedAfter).toBeLessThanOrEqual(
+      plan.targetTokens + tolerance,
+    );
   });
 
   it("returns a compactThroughIndex and compacts an even number of messages", () => {
@@ -268,6 +273,49 @@ describe("planCompaction", () => {
     const plan = planCompaction(history, { inputBudget: 3000 });
     expect(plan.messagesToCompact.length % 2).toBe(0);
     expect(plan.compactThroughIndex).toBe(plan.messagesToCompact.length);
+  });
+
+  it("kept set is a contiguous newest suffix even with variable message sizes", () => {
+    // Alternating big/small messages: 200-char msg, 20-char msg, 200, 20, …
+    const history: ChatMessage[] = [];
+    for (let i = 0; i < 30; i++) {
+      history.push({
+        role: i % 2 === 0 ? "user" : "assistant",
+        content: `msg ${i} ` + (i % 2 === 0 ? "x".repeat(200) : "x".repeat(20)),
+      });
+    }
+    const plan = planCompaction(history, { inputBudget: 3000 });
+    // Messages-to-compact should be a contiguous block history[1..K].
+    // Verify every index in messagesToCompact is consecutive starting at 1.
+    const compactIndices = plan.messagesToCompact.map((m) =>
+      history.findIndex((h) => h.content === m.content),
+    );
+    for (let i = 0; i < compactIndices.length; i++) {
+      expect(compactIndices[i]).toBe(i + 1);
+    }
+    // And compactThroughIndex matches.
+    expect(plan.compactThroughIndex).toBe(compactIndices[compactIndices.length - 1]);
+  });
+
+  it("estimated post-compaction usage lands near target regardless of existing summary", () => {
+    // baseFixed uses only the anchor (system + seed + firstUser content),
+    // NOT the existing summary. So post-compaction estimates should fit
+    // under target whether or not there is an existing summary to replace.
+    const history = makeHistory(20, (i) => `msg ${i} ` + "x".repeat(200));
+    const bare = planCompaction(history, { inputBudget: 6000 });
+    const withOldSummary = planCompaction(history, {
+      inputBudget: 6000,
+      existingSummary: "x".repeat(2000),
+    });
+    // Tolerance covers one kept message's cost — the even-count invariant
+    // can spare one message back into history, nudging usage above target.
+    const tolerance = Math.max(100, Math.floor(bare.targetTokens * 0.1));
+    expect(bare.estimatedUsedAfter).toBeLessThanOrEqual(
+      bare.targetTokens + tolerance,
+    );
+    expect(withOldSummary.estimatedUsedAfter).toBeLessThanOrEqual(
+      withOldSummary.targetTokens + tolerance,
+    );
   });
 
   it("removing the compacted block + applying summary actually shrinks the request", () => {

--- a/apps/llm-client/src/lib/context-manager.test.ts
+++ b/apps/llm-client/src/lib/context-manager.test.ts
@@ -7,6 +7,7 @@ import {
   effectiveMaxTokens,
   INPUT_BUDGET,
   PER_SLOT_CTX,
+  planCompaction,
   previewContext,
   REPLY_BUDGET,
   SAFETY,
@@ -220,13 +221,83 @@ describe("previewContext", () => {
     expect(preview.usedPercent).toBeLessThanOrEqual(100);
   });
 
-  it("respects summaryBudgetPct cap", () => {
-    const history = makeHistory(3);
-    const preview = previewContext(history, "", {
-      inputBudget: 1000,
-      summary: "x".repeat(4000),
-      summaryBudgetPct: 10,
+});
+
+describe("planCompaction", () => {
+  it("targets half of current usage", () => {
+    const history = makeHistory(30, (i) => `msg ${i} ` + "x".repeat(200));
+    const plan = planCompaction(history, { inputBudget: 10000 });
+    // target should be ~= currentUsedTokens / 2
+    expect(plan.targetTokens).toBeGreaterThan(0);
+    expect(plan.targetTokens).toBeLessThanOrEqual(plan.currentUsedTokens);
+    expect(Math.abs(plan.targetTokens - Math.floor(plan.currentUsedTokens / 2))).toBeLessThanOrEqual(200);
+  });
+
+  it("compacts oldest non-anchored messages, leaves recent ones kept", () => {
+    const history = makeHistory(30, (i) => `msg ${i} ` + "x".repeat(200));
+    const plan = planCompaction(history, { inputBudget: 10000 });
+    expect(plan.messagesToCompact.length).toBeGreaterThan(0);
+    // First compacted item is the earliest non-anchor, i.e. index 1.
+    expect(plan.messagesToCompact[0].content).toContain("msg 1");
+    // First user message (anchor) is never compacted.
+    for (const m of plan.messagesToCompact) {
+      expect(m.content).not.toBe(history[0].content);
+    }
+  });
+
+  it("no-ops when there is nothing older than the anchor to compact", () => {
+    const history = makeHistory(1);
+    const plan = planCompaction(history, { inputBudget: 10000 });
+    expect(plan.messagesToCompact).toHaveLength(0);
+  });
+
+  it("summary token budget is at least 64", () => {
+    const history = makeHistory(4);
+    const plan = planCompaction(history, { inputBudget: 200 });
+    expect(plan.summaryTokenBudget).toBeGreaterThanOrEqual(64);
+  });
+
+  it("estimated usage after compaction is ≤ target", () => {
+    const history = makeHistory(40, (i) => `msg ${i} ` + "x".repeat(100));
+    const plan = planCompaction(history, { inputBudget: 8000 });
+    expect(plan.estimatedUsedAfter).toBeLessThanOrEqual(plan.targetTokens + 8);
+  });
+
+  it("returns a compactThroughIndex and compacts an even number of messages", () => {
+    const history = makeHistory(30, (i) => `msg ${i} ` + "x".repeat(150));
+    const plan = planCompaction(history, { inputBudget: 3000 });
+    expect(plan.messagesToCompact.length % 2).toBe(0);
+    expect(plan.compactThroughIndex).toBe(plan.messagesToCompact.length);
+  });
+
+  it("removing the compacted block + applying summary actually shrinks the request", () => {
+    // 20 chunky messages simulating a chat near 80% of the input budget.
+    const history = makeHistory(20, (i) => `msg ${i} ` + "x".repeat(200));
+    const before = buildRequestMessages(history, { inputBudget: 10000 });
+    const beforeTokens = estimateMessagesJoined(before.messages);
+
+    const plan = planCompaction(history, { inputBudget: 10000 });
+    expect(plan.messagesToCompact.length).toBeGreaterThan(0);
+
+    // Simulate what runCompaction does: drop history[1..compactThroughIndex],
+    // then build with a summary that fits the summarizer's budget.
+    const remaining = [
+      history[0],
+      ...history.slice(plan.compactThroughIndex + 1),
+    ];
+    const summary = "x".repeat(plan.summaryTokenBudget * 3); // ~0.75 of budget
+    const after = buildRequestMessages(remaining, {
+      inputBudget: 10000,
+      summary,
     });
-    expect(preview.summaryTokens).toBeLessThanOrEqual(100 + 4);
+    const afterTokens = estimateMessagesJoined(after.messages);
+
+    expect(afterTokens).toBeLessThan(beforeTokens);
   });
 });
+
+function estimateMessagesJoined(messages: ChatMessage[]): number {
+  // Rough token count matching the in-app heuristic (chars/4).
+  const joined = messages.map((m) => m.content).join("");
+  return Math.ceil(joined.length / 4);
+}

--- a/apps/llm-client/src/lib/context-manager.ts
+++ b/apps/llm-client/src/lib/context-manager.ts
@@ -79,10 +79,18 @@ export function buildRequestMessages(
     : null;
   const systemCost = systemMsg ? estimateTokens(systemMsg.content) + 4 : 0;
 
-  // Summary is trusted at face value; it was sized by the summarizer at
-  // compaction time. If it still overshoots budget, tail-drop trims older
-  // chat messages to make room.
-  const effectiveSummary = summary ?? "";
+  // Summary is trusted at face value from the summarizer, but we still
+  // clamp to half the input budget as a hard safety net — if an upstream
+  // bug produced a runaway summary we don't want to blow past ctx.
+  const summaryCap = Math.max(128, Math.floor(budget * 0.5));
+  let effectiveSummary = summary ?? "";
+  if (effectiveSummary && estimateTokens(effectiveSummary) > summaryCap) {
+    const before = estimateTokens(effectiveSummary);
+    effectiveSummary = effectiveSummary.slice(0, summaryCap * 4);
+    log.warn(
+      `buildRequestMessages: summary over cap (${before} > ${summaryCap}), truncating`,
+    );
+  }
 
   // Seed + summary: both prepended to first user message content.
   // This avoids breaking chat templates that require strict role alternation.
@@ -229,71 +237,80 @@ export function planCompaction(
     history.length > 0 && history[0].role === "user" ? history[0] : null;
   const summaryTrimmed = existingSummary?.trim() ?? "";
   const seedTrimmed = seedPrompt?.trim() ?? "";
-  const firstPrefix =
-    (seedTrimmed ? seedTrimmed + "\n\n" : "") +
-    (summaryTrimmed ? `[Story so far]: ${summaryTrimmed}\n\n` : "");
-  const firstFullContent = firstPrefix + (firstUser?.content ?? "");
-  const firstUserCost = firstUser ? estimateTokens(firstFullContent) + 4 : 0;
-  const baseFixed = systemCost + firstUserCost + 2;
 
-  // Current used tokens = the whole request if sent as-is (no compaction).
+  // Anchor = system + (seed + firstUser content), no summary. This is the
+  // floor that every request — pre- or post-compaction — carries.
+  const firstAnchorContent =
+    (seedTrimmed ? seedTrimmed + "\n\n" : "") + (firstUser?.content ?? "");
+  const firstUserAnchorCost = firstUser
+    ? estimateTokens(firstAnchorContent) + 4
+    : 0;
+  const baseFixedAnchor = systemCost + firstUserAnchorCost + 2;
+
+  // The existing summary (if any) is currently embedded in the first user
+  // message. Account for it so currentUsedTokens matches the real request
+  // size, but do NOT use it when sizing the NEW summary + kept messages —
+  // the new summary replaces the old one.
+  const existingSummaryCost = summaryTrimmed
+    ? estimateTokens(`[Story so far]: ${summaryTrimmed}\n\n`)
+    : 0;
+
   let recentCost = 0;
   for (let i = 1; i < history.length; i++) {
     recentCost += estimateTokens(history[i].content) + 4;
   }
   const currentUsedTokens = Math.min(
     inputBudget,
-    baseFixed + recentCost,
+    baseFixedAnchor + existingSummaryCost + recentCost,
   );
 
-  // Target: half of current usage, floored so we don't undershoot room for
-  // the model's reply plus the always-anchored first message.
-  const targetTokens = Math.max(baseFixed + 128, Math.floor(currentUsedTokens / 2));
+  // Target: half of current usage, floored so we leave at least 128 tokens
+  // for something other than the anchor.
+  const targetTokens = Math.max(
+    baseFixedAnchor + 128,
+    Math.floor(currentUsedTokens / 2),
+  );
 
-  // Summary gets at most half of the room above baseFixed. The remaining
-  // half is budget for recent messages.
-  const targetRoom = Math.max(0, targetTokens - baseFixed);
+  // Split the post-compaction room evenly between the new summary and
+  // recent kept messages.
+  const targetRoom = Math.max(0, targetTokens - baseFixedAnchor);
   const summaryTokenBudget = Math.max(64, Math.floor(targetRoom * 0.5));
   const recentBudget = Math.max(0, targetRoom - summaryTokenBudget);
 
+  // Find the contiguous newest-suffix that fits recentBudget. Walk forward
+  // from the end; stop when adding one more message would overflow.
   const startIdx = firstUser ? 1 : 0;
-  const keptReverse: ChatMessage[] = [];
-  const compactReverse: ChatMessage[] = [];
-  let used = 0;
+  let suffixStart = history.length;
+  let suffixUsed = 0;
   for (let i = history.length - 1; i >= startIdx; i--) {
     const cost = estimateTokens(history[i].content) + 4;
-    if (used + cost <= recentBudget) {
-      keptReverse.push(history[i]);
-      used += cost;
-    } else {
-      compactReverse.push(history[i]);
-    }
+    if (suffixUsed + cost > recentBudget) break;
+    suffixUsed += cost;
+    suffixStart = i;
   }
-  // compactReverse is newest→oldest; the oldest-first ordering is what the
-  // summarizer expects.
-  const compactOldestFirst = compactReverse.slice().reverse();
 
-  // The compacted block is history[startIdx..startIdx + N - 1]. Removing it
-  // must preserve role alternation — msg 0 is a user; the next message left
-  // over after removal also alternates, so the count we remove must be even
-  // (each pair is user+assistant). If we landed on an odd count, leave the
-  // newest-of-compact in history and shorten the block by one.
-  if (compactOldestFirst.length % 2 === 1) {
-    const spared = compactOldestFirst.pop();
+  // The compacted block is history[startIdx..suffixStart - 1]. Its length
+  // must be even to preserve role alternation after removal (msg 0 is user;
+  // each user+assistant pair we drop keeps alternation intact). If odd,
+  // spare the newest-of-compact by bumping suffixStart up by one.
+  let compactLength = suffixStart - startIdx;
+  if (compactLength % 2 === 1) {
+    const spared = history[suffixStart - 1];
+    suffixStart -= 1;
+    compactLength -= 1;
     if (spared) {
-      used += estimateTokens(spared.content) + 4;
+      suffixUsed += estimateTokens(spared.content) + 4;
     }
   }
 
-  const messagesToCompact = compactOldestFirst;
+  const messagesToCompact = history.slice(startIdx, suffixStart);
   const compactThroughIndex =
-    messagesToCompact.length === 0
-      ? -1
-      : startIdx + messagesToCompact.length - 1;
-  const estimatedUsedAfter = baseFixed + summaryTokenBudget + used;
+    compactLength === 0 ? -1 : suffixStart - 1;
+  const estimatedUsedAfter =
+    baseFixedAnchor + summaryTokenBudget + suffixUsed;
 
   log.info(
-    `planCompaction: currentUsed=${currentUsedTokens} target=${targetTokens} baseFixed=${baseFixed} summaryBudget=${summaryTokenBudget} recentBudget=${recentBudget} toCompact=${messagesToCompact.length} compactThroughIdx=${compactThroughIndex} kept=${keptReverse.length} estAfter=${estimatedUsedAfter}`,
+    `planCompaction: currentUsed=${currentUsedTokens} target=${targetTokens} anchor=${baseFixedAnchor} existingSummary=${existingSummaryCost} summaryBudget=${summaryTokenBudget} recentBudget=${recentBudget} toCompact=${messagesToCompact.length} compactThroughIdx=${compactThroughIndex} kept=${history.length - suffixStart} estAfter=${estimatedUsedAfter}`,
   );
 
   return {

--- a/apps/llm-client/src/lib/context-manager.ts
+++ b/apps/llm-client/src/lib/context-manager.ts
@@ -45,7 +45,6 @@ export interface BuildOptions {
   systemPrompt?: string;
   seedPrompt?: string;
   summary?: string;
-  summaryBudgetPct?: number;
 }
 
 export interface BuildResult {
@@ -74,29 +73,16 @@ export function buildRequestMessages(
   const systemPrompt = options.systemPrompt?.trim();
   const seedPrompt = options.seedPrompt?.trim();
   const summary = options.summary?.trim();
-  const summaryBudgetPct = options.summaryBudgetPct ?? 25;
-  const summaryBudgetTokens = Math.floor(
-    (budget * summaryBudgetPct) / 100,
-  );
 
   const systemMsg: ChatMessage | null = systemPrompt
     ? { role: "system", content: systemPrompt }
     : null;
   const systemCost = systemMsg ? estimateTokens(systemMsg.content) + 4 : 0;
 
-  // Summary: truncated to fit within the summary budget.
-  let effectiveSummary = "";
-  let summaryCost = 0;
-  if (summary) {
-    const rawCost = estimateTokens(summary);
-    if (rawCost <= summaryBudgetTokens) {
-      effectiveSummary = summary;
-      summaryCost = rawCost;
-    } else {
-      effectiveSummary = summary.slice(0, summaryBudgetTokens * 4);
-      summaryCost = summaryBudgetTokens;
-    }
-  }
+  // Summary is trusted at face value; it was sized by the summarizer at
+  // compaction time. If it still overshoots budget, tail-drop trims older
+  // chat messages to make room.
+  const effectiveSummary = summary ?? "";
 
   // Seed + summary: both prepended to first user message content.
   // This avoids breaking chat templates that require strict role alternation.
@@ -205,6 +191,121 @@ export function totalTokenEstimate(messages: ChatMessage[]): number {
   return estimateMessagesTokens(messages);
 }
 
+export interface CompactionPlan {
+  messagesToCompact: ChatMessage[];
+  /** Inclusive index of the last message that should be removed from history
+   *  after the summary is written. -1 when nothing is compacted. Caller should
+   *  splice history[1..compactThroughIndex] out of the chat. */
+  compactThroughIndex: number;
+  summaryTokenBudget: number;
+  targetTokens: number;
+  currentUsedTokens: number;
+  estimatedUsedAfter: number;
+}
+
+export interface CompactionPlanOptions {
+  inputBudget: number;
+  systemPrompt?: string;
+  seedPrompt?: string;
+  existingSummary?: string;
+}
+
+/**
+ * Plan compaction: target tokens = current-used / 2. Picks oldest
+ * non-anchored messages to fold into the story-so-far so the rebuilt
+ * request lands near the target. Summary gets up to half of the target
+ * room; the rest is reserved for the most recent messages.
+ */
+export function planCompaction(
+  history: ChatMessage[],
+  options: CompactionPlanOptions,
+): CompactionPlan {
+  const { inputBudget, systemPrompt, seedPrompt, existingSummary } = options;
+
+  const systemCost = systemPrompt?.trim()
+    ? estimateTokens(systemPrompt) + 4
+    : 0;
+  const firstUser =
+    history.length > 0 && history[0].role === "user" ? history[0] : null;
+  const summaryTrimmed = existingSummary?.trim() ?? "";
+  const seedTrimmed = seedPrompt?.trim() ?? "";
+  const firstPrefix =
+    (seedTrimmed ? seedTrimmed + "\n\n" : "") +
+    (summaryTrimmed ? `[Story so far]: ${summaryTrimmed}\n\n` : "");
+  const firstFullContent = firstPrefix + (firstUser?.content ?? "");
+  const firstUserCost = firstUser ? estimateTokens(firstFullContent) + 4 : 0;
+  const baseFixed = systemCost + firstUserCost + 2;
+
+  // Current used tokens = the whole request if sent as-is (no compaction).
+  let recentCost = 0;
+  for (let i = 1; i < history.length; i++) {
+    recentCost += estimateTokens(history[i].content) + 4;
+  }
+  const currentUsedTokens = Math.min(
+    inputBudget,
+    baseFixed + recentCost,
+  );
+
+  // Target: half of current usage, floored so we don't undershoot room for
+  // the model's reply plus the always-anchored first message.
+  const targetTokens = Math.max(baseFixed + 128, Math.floor(currentUsedTokens / 2));
+
+  // Summary gets at most half of the room above baseFixed. The remaining
+  // half is budget for recent messages.
+  const targetRoom = Math.max(0, targetTokens - baseFixed);
+  const summaryTokenBudget = Math.max(64, Math.floor(targetRoom * 0.5));
+  const recentBudget = Math.max(0, targetRoom - summaryTokenBudget);
+
+  const startIdx = firstUser ? 1 : 0;
+  const keptReverse: ChatMessage[] = [];
+  const compactReverse: ChatMessage[] = [];
+  let used = 0;
+  for (let i = history.length - 1; i >= startIdx; i--) {
+    const cost = estimateTokens(history[i].content) + 4;
+    if (used + cost <= recentBudget) {
+      keptReverse.push(history[i]);
+      used += cost;
+    } else {
+      compactReverse.push(history[i]);
+    }
+  }
+  // compactReverse is newest→oldest; the oldest-first ordering is what the
+  // summarizer expects.
+  const compactOldestFirst = compactReverse.slice().reverse();
+
+  // The compacted block is history[startIdx..startIdx + N - 1]. Removing it
+  // must preserve role alternation — msg 0 is a user; the next message left
+  // over after removal also alternates, so the count we remove must be even
+  // (each pair is user+assistant). If we landed on an odd count, leave the
+  // newest-of-compact in history and shorten the block by one.
+  if (compactOldestFirst.length % 2 === 1) {
+    const spared = compactOldestFirst.pop();
+    if (spared) {
+      used += estimateTokens(spared.content) + 4;
+    }
+  }
+
+  const messagesToCompact = compactOldestFirst;
+  const compactThroughIndex =
+    messagesToCompact.length === 0
+      ? -1
+      : startIdx + messagesToCompact.length - 1;
+  const estimatedUsedAfter = baseFixed + summaryTokenBudget + used;
+
+  log.info(
+    `planCompaction: currentUsed=${currentUsedTokens} target=${targetTokens} baseFixed=${baseFixed} summaryBudget=${summaryTokenBudget} recentBudget=${recentBudget} toCompact=${messagesToCompact.length} compactThroughIdx=${compactThroughIndex} kept=${keptReverse.length} estAfter=${estimatedUsedAfter}`,
+  );
+
+  return {
+    messagesToCompact,
+    compactThroughIndex,
+    summaryTokenBudget,
+    targetTokens,
+    currentUsedTokens,
+    estimatedUsedAfter,
+  };
+}
+
 export interface ContextPreview {
   inputBudget: number;
   usedTokens: number;
@@ -223,20 +324,13 @@ export function previewContext(
     systemPrompt?: string;
     seedPrompt?: string;
     summary?: string;
-    summaryBudgetPct?: number;
   },
 ): ContextPreview {
   const systemCost = opts.systemPrompt
     ? estimateTokens(opts.systemPrompt) + 4
     : 0;
   const draftCost = draft ? estimateTokens(draft) + 4 : 0;
-  const summaryBudgetPct = opts.summaryBudgetPct ?? 25;
-  const summaryBudgetTokens = Math.floor(
-    (opts.inputBudget * summaryBudgetPct) / 100,
-  );
-  const summaryTokens = opts.summary
-    ? Math.min(estimateTokens(opts.summary), summaryBudgetTokens)
-    : 0;
+  const summaryTokens = opts.summary ? estimateTokens(opts.summary) : 0;
 
   // Build the combined first-message content (seed + summary + first user msg)
   const hasFirstUser = history.length > 0 && history[0].role === "user";
@@ -245,17 +339,13 @@ export function previewContext(
     firstMsgContent = opts.seedPrompt + "\n\n" + firstMsgContent;
   }
   if (opts.summary && hasFirstUser) {
-    const effectiveSummary =
-      estimateTokens(opts.summary) <= summaryBudgetTokens
-        ? opts.summary
-        : opts.summary.slice(0, summaryBudgetTokens * 4);
     const sep = opts.seedPrompt ? "\n\n" : "";
     firstMsgContent = firstMsgContent.replace(
       history[0].content,
-      `${sep}[Story so far]: ${effectiveSummary}\n\n${history[0].content}`,
+      `${sep}[Story so far]: ${opts.summary}\n\n${history[0].content}`,
     );
     if (!opts.seedPrompt) {
-      firstMsgContent = `[Story so far]: ${effectiveSummary}\n\n${history[0].content}`;
+      firstMsgContent = `[Story so far]: ${opts.summary}\n\n${history[0].content}`;
     }
   }
   const seedCost = hasFirstUser

--- a/apps/llm-client/src/lib/generate-choices.ts
+++ b/apps/llm-client/src/lib/generate-choices.ts
@@ -67,8 +67,14 @@ export async function generateChoices(
 
       const json = (await res.json()) as {
         choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
       };
       const text = json.choices?.[0]?.message?.content?.trim();
+      if (json.usage) {
+        log.info(
+          `generateChoices: call ${i + 1} usage prompt=${json.usage.prompt_tokens} completion=${json.usage.completion_tokens}`,
+        );
+      }
       if (text) {
         // Strip numbering prefix and wrapping quotes the model might add
         const cleaned = text

--- a/apps/llm-client/src/lib/generate-title.ts
+++ b/apps/llm-client/src/lib/generate-title.ts
@@ -40,11 +40,18 @@ export async function generateTitle(
     if (!res.ok) return null;
     const json = (await res.json()) as {
       choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
     };
     const raw = json.choices?.[0]?.message?.content?.trim();
     if (!raw) return null;
     const title = raw.replace(/^["']|["']$/g, "").slice(0, 60);
-    log.info(`generateTitle: "${title}"`);
+    if (json.usage) {
+      log.info(
+        `generateTitle: "${title}" (prompt=${json.usage.prompt_tokens} completion=${json.usage.completion_tokens})`,
+      );
+    } else {
+      log.info(`generateTitle: "${title}"`);
+    }
     return title;
   } catch {
     return null;

--- a/apps/llm-client/src/lib/llama-client.test.ts
+++ b/apps/llm-client/src/lib/llama-client.test.ts
@@ -27,6 +27,13 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function deltaText(evts: { type: string }[]): string {
+  return evts
+    .filter((e): e is { type: "delta"; content: string } => e.type === "delta")
+    .map((e) => e.content)
+    .join("");
+}
+
 describe("streamChat", () => {
   it("yields deltas in order and stops on [DONE]", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -40,15 +47,47 @@ describe("streamChat", () => {
     );
 
     const controller = new AbortController();
-    const out: string[] = [];
-    for await (const token of streamChat({
+    const out: Awaited<ReturnType<typeof streamChat>> extends AsyncGenerator<infer T>
+      ? T[]
+      : never = [];
+    for await (const event of streamChat({
       messages: [{ role: "user", content: "hi" }],
       signal: controller.signal,
       maxTokens: 128,
     })) {
-      out.push(token);
+      out.push(event);
     }
-    expect(out.join("")).toBe("Hello world");
+    expect(deltaText(out)).toBe("Hello world");
+  });
+
+  it("yields a usage event when the server sends it", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockSSEResponse([
+        dataEvent(delta("hi")),
+        dataEvent({
+          choices: [],
+          usage: { prompt_tokens: 42, completion_tokens: 7, total_tokens: 49 },
+        }),
+        "data: [DONE]\n\n",
+      ]),
+    );
+    const events: Awaited<ReturnType<typeof streamChat>> extends AsyncGenerator<infer T>
+      ? T[]
+      : never = [];
+    for await (const e of streamChat({
+      messages: [{ role: "user", content: "hi" }],
+      signal: new AbortController().signal,
+      maxTokens: 16,
+    })) {
+      events.push(e);
+    }
+    const usage = events.find((e) => e.type === "usage");
+    expect(usage).toBeTruthy();
+    if (usage && usage.type === "usage") {
+      expect(usage.usage.promptTokens).toBe(42);
+      expect(usage.usage.completionTokens).toBe(7);
+      expect(usage.usage.totalTokens).toBe(49);
+    }
   });
 
   it("ignores malformed JSON data lines", async () => {
@@ -59,15 +98,15 @@ describe("streamChat", () => {
         "data: [DONE]\n\n",
       ]),
     );
-    const out: string[] = [];
-    for await (const tok of streamChat({
+    const out: { type: string }[] = [];
+    for await (const e of streamChat({
       messages: [{ role: "user", content: "hi" }],
       signal: new AbortController().signal,
       maxTokens: 16,
     })) {
-      out.push(tok);
+      out.push(e);
     }
-    expect(out.join("")).toBe("ok");
+    expect(deltaText(out)).toBe("ok");
   });
 
   it("handles events split across chunks", async () => {
@@ -80,15 +119,15 @@ describe("streamChat", () => {
         "data: [DONE]\n\n",
       ]),
     );
-    const out: string[] = [];
-    for await (const tok of streamChat({
+    const out: { type: string }[] = [];
+    for await (const e of streamChat({
       messages: [{ role: "user", content: "hi" }],
       signal: new AbortController().signal,
       maxTokens: 16,
     })) {
-      out.push(tok);
+      out.push(e);
     }
-    expect(out.join("")).toBe("hello");
+    expect(deltaText(out)).toBe("hello");
   });
 
   it("throws LlamaClientError on non-ok response", async () => {

--- a/apps/llm-client/src/lib/llama-client.ts
+++ b/apps/llm-client/src/lib/llama-client.ts
@@ -23,9 +23,19 @@ export class LlamaClientError extends Error {
   }
 }
 
+export interface ChatUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+export type StreamEvent =
+  | { type: "delta"; content: string }
+  | { type: "usage"; usage: ChatUsage };
+
 export async function* streamChat(
   options: StreamChatOptions,
-): AsyncGenerator<string> {
+): AsyncGenerator<StreamEvent> {
   const endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
   const url = `${endpoint.replace(/\/$/, "")}/v1/chat/completions`;
 
@@ -41,6 +51,7 @@ export async function* streamChat(
       model: options.model ?? apiModel(),
       messages: options.messages,
       stream: true,
+      stream_options: { include_usage: true },
       max_tokens: options.maxTokens,
       temperature: options.temperature ?? 0.7,
     }),
@@ -85,7 +96,25 @@ export async function* streamChat(
             const parsed = JSON.parse(data);
             const delta: string | undefined =
               parsed?.choices?.[0]?.delta?.content;
-            if (delta) yield delta;
+            if (delta) yield { type: "delta", content: delta };
+            const usage = parsed?.usage;
+            if (
+              usage &&
+              typeof usage.prompt_tokens === "number" &&
+              typeof usage.completion_tokens === "number"
+            ) {
+              yield {
+                type: "usage",
+                usage: {
+                  promptTokens: usage.prompt_tokens,
+                  completionTokens: usage.completion_tokens,
+                  totalTokens:
+                    typeof usage.total_tokens === "number"
+                      ? usage.total_tokens
+                      : usage.prompt_tokens + usage.completion_tokens,
+                },
+              };
+            }
           } catch {
             // Ignore malformed JSON chunks.
           }

--- a/apps/llm-client/src/lib/summarize.ts
+++ b/apps/llm-client/src/lib/summarize.ts
@@ -62,9 +62,15 @@ async function callModel(
     }
     const json = (await res.json()) as {
       choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
     };
     const content = json.choices?.[0]?.message?.content?.trim() ?? null;
     if (!content) log.warn("summarize: model returned empty content");
+    if (json.usage) {
+      log.info(
+        `summarize: usage prompt=${json.usage.prompt_tokens} completion=${json.usage.completion_tokens}`,
+      );
+    }
     log.exchange("exchange:compaction", {
       messages: [
         { role: "system", content: systemContent },

--- a/apps/llm-client/src/store/chat-store.ts
+++ b/apps/llm-client/src/store/chat-store.ts
@@ -7,6 +7,11 @@ export interface Message {
   role: ChatRole;
   content: string;
   createdAt: number;
+  /** Real input token count for the request that produced this message
+   *  (assistant only — the server's prompt_tokens). */
+  promptTokens?: number;
+  /** Real output token count for this message (assistant only). */
+  completionTokens?: number;
 }
 
 export interface Chat {
@@ -38,6 +43,15 @@ export interface ChatStore {
     msg: Omit<Message, "id" | "createdAt">,
   ): string;
   appendToLastMessage(chatId: string, delta: string): void;
+  setMessageUsage(
+    chatId: string,
+    messageId: string,
+    promptTokens: number,
+    completionTokens: number,
+  ): void;
+  /** Remove messages[fromIdx..toIdx] inclusive. Used by compaction to delete
+   *  the messages that were folded into the story-so-far. */
+  dropMessagesInRange(chatId: string, fromIdx: number, toIdx: number): void;
   setSummary(chatId: string, summary: string): void;
   setStreaming(streaming: StreamingState | null): void;
 }
@@ -141,6 +155,50 @@ export const useChatStore = create<ChatStore>()(
           };
         });
         return id;
+      },
+
+      dropMessagesInRange(chatId, fromIdx, toIdx) {
+        set((s) => {
+          const chat = s.chats[chatId];
+          if (!chat) return s;
+          if (
+            fromIdx < 0 ||
+            toIdx < fromIdx ||
+            toIdx >= chat.messages.length
+          ) {
+            return s;
+          }
+          const before = chat.messages.slice(0, fromIdx);
+          const after = chat.messages.slice(toIdx + 1);
+          const messages = [...before, ...after];
+          return {
+            chats: {
+              ...s.chats,
+              [chatId]: { ...chat, messages, updatedAt: Date.now() },
+            },
+          };
+        });
+      },
+
+      setMessageUsage(chatId, messageId, promptTokens, completionTokens) {
+        set((s) => {
+          const chat = s.chats[chatId];
+          if (!chat) return s;
+          const idx = chat.messages.findIndex((m) => m.id === messageId);
+          if (idx < 0) return s;
+          const messages = chat.messages.slice();
+          messages[idx] = {
+            ...messages[idx],
+            promptTokens,
+            completionTokens,
+          };
+          return {
+            chats: {
+              ...s.chats,
+              [chatId]: { ...chat, messages, updatedAt: Date.now() },
+            },
+          };
+        });
       },
 
       appendToLastMessage(chatId, delta) {

--- a/apps/llm-client/src/store/settings-store.ts
+++ b/apps/llm-client/src/store/settings-store.ts
@@ -25,7 +25,7 @@ export interface SettingsStore {
   contextOverride: number | null;
   replyBudgetOverride: number | null;
   autoSummarize: boolean;
-  summaryBudgetPct: number;
+  showTokenCount: boolean;
   deduplicateRetry: boolean;
   temperature: number;
   colorSupport: boolean;
@@ -53,7 +53,7 @@ export interface SettingsStore {
   setContextOverride(next: number | null): void;
   setReplyBudgetOverride(next: number | null): void;
   setAutoSummarize(v: boolean): void;
-  setSummaryBudgetPct(v: number): void;
+  setShowTokenCount(v: boolean): void;
   setDeduplicateRetry(v: boolean): void;
   setTemperature(v: number): void;
   setColorSupport(v: boolean): void;
@@ -89,7 +89,7 @@ export const useSettingsStore = create<SettingsStore>()(
       contextOverride: null,
       replyBudgetOverride: null,
       autoSummarize: true,
-      summaryBudgetPct: 25,
+      showTokenCount: true,
       deduplicateRetry: true,
       temperature: 0.7,
       colorSupport: false,
@@ -143,8 +143,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setAutoSummarize(v) {
         set({ autoSummarize: v });
       },
-      setSummaryBudgetPct(v) {
-        set({ summaryBudgetPct: Math.max(5, Math.min(50, v)) });
+      setShowTokenCount(v) {
+        set({ showTokenCount: v });
       },
       setDeduplicateRetry(v) {
         set({ deduplicateRetry: v });
@@ -183,6 +183,8 @@ export const useSettingsStore = create<SettingsStore>()(
           // Remove stale keys from older versions
           delete p.colorPrompt;
           delete p.extractChoices;
+          delete p.summaryBudgetPct;
+          delete p.compactionTargetPct;
         }
         return {
           ...current,


### PR DESCRIPTION
## Summary

- **Compaction redesign**: every compact run (auto at 80% ctx, or manual via the new `compact` link) now targets **half of the current context usage**. Dropped the Summary budget and Compaction target sliders — one knob is enough.
- **Compact actually shrinks ctx**: the prior change only wrote the new summary; the compacted messages stayed in history and usage *went up*. `runCompaction` now deletes the compacted range from the chat so the summary replaces them. Even-count invariant preserves user/assistant alternation.
- **Real token usage**: `streamChat` sets `stream_options.include_usage` and yields a `StreamEvent` union (`delta` | `usage`). The non-stream helpers (summarize / title / choices / colorize) log `response.usage`. Per-message token counts render under each bubble (Settings → Show token count, default on); suffix `~` marks estimates, absence marks real server counts.
- **Story-so-far panel** now renders whenever `chat.summary` is set — the prior gate only fired on tail-drop, so manual compact results were invisible.

## Test plan
- [x] `pnpm test` — 108/108 pass, including new `planCompaction` cases + a ctx-shrinks-after-compact invariant.
- [x] `pnpm build` clean.
- [x] Playwright check: seeded chat at 27% ctx, clicked `compact` → **9% ctx**, 14 messages → 4 messages, Story so far panel visible.
- [ ] Manual smoke against real llama-server / OpenRouter to confirm the `usage` payload is being captured and rendered.

Version bump 0.1.1 → 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added manual compaction control: click the "compact" link to halve context usage on demand.
  - Token count display shows real server usage metrics for messages (when enabled in settings).

* **Improvements**
  - Rolling compaction algorithm refined to target half of current context usage per run.
  - Settings UI updated: "Show token count" toggle replaces the summary budget slider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->