### PR TITLE
blog: add headless launch example to cheat-sheet

### DIFF
--- a/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
+++ b/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
@@ -87,7 +87,32 @@ too so it doesn't freeze on permission requests. Consider some of these launch f
 Note: `--system-prompt` and `--system-prompt-file` are mutually exclusive;
 `--append-*` variants compose with either.
 
-Then run it, for example
+Then run it. A complete example, with the token sourced from a secret
+and the run capped on turns and spend:
+
+```bash
+# One-time, on a dev box. Copy the printed token into your secret store
+# (Vault, k8s Secret, GitHub Actions secret, whatever you use).
+claude setup-token
+
+# At runtime, in the container or job:
+export CLAUDE_CODE_OAUTH_TOKEN="$(cat /vault/secrets/claude_oauth_token)"
+
+claude \
+  -p "$CLAUDE_PROMPT" \
+  --model sonnet \
+  --output-format json \
+  --permission-mode bypassPermissions \
+  --max-turns 10 \
+  --max-budget-usd 2.00 \
+  --no-session-persistence
+```
+
+That gives you JSON output for downstream parsing, a hard cap on agentic
+turns, a dollar ceiling so a runaway job can't drain your account, and
+no session file written to disk. Drop the `--max-*` flags if you trust
+the prompt, swap `bypassPermissions` for `auto` if you want the
+auto-mode classifier to gate risky calls.
 
 ---
 

--- a/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
+++ b/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
@@ -42,9 +42,17 @@ Useful to know what these are
 
 
 
-# Launch headless Claude, ex for Docker/Kubernetes
+# Launch headless Claude, ex in Kubernetes cron jobs
 
-Install it in a Dockerfile.
+Install it in a Dockerfile. I like to launch it from k8s in a CronJob from there.
+
+
+`vi Dockerfile`
+```dockerfile
+FROM node:22-slim
+RUN npm i -g @anthropic-ai/claude-code
+```
+
 
 Collect the value for `CLAUDE_CODE_OAUTH_TOKEN`.
 ```bash
@@ -59,7 +67,6 @@ claude \
   --output-format json \
   --m opus \
   -p $CLAUDE_PROMPT
-
 ```
 
 You'll probably also want to use `--permission-mode auto` or `--dangerously-skip-permissions`
@@ -87,17 +94,9 @@ too so it doesn't freeze on permission requests. Consider some of these launch f
 Note: `--system-prompt` and `--system-prompt-file` are mutually exclusive;
 `--append-*` variants compose with either.
 
-Then run it. A complete example, with the token sourced from a secret
-and the run capped on turns and spend:
+Then run it. Another example:
 
 ```bash
-# One-time, on a dev box. Copy the printed token into your secret store
-# (Vault, k8s Secret, GitHub Actions secret, whatever you use).
-claude setup-token
-
-# At runtime, in the container or job:
-export CLAUDE_CODE_OAUTH_TOKEN="$(cat /vault/secrets/claude_oauth_token)"
-
 claude \
   -p "$CLAUDE_PROMPT" \
   --model sonnet \
@@ -108,7 +107,7 @@ claude \
   --no-session-persistence
 ```
 
-That gives you JSON output for downstream parsing, a hard cap on agentic
+This'd give you JSON output for parsing (datadog etc), a hard cap on agentic
 turns, a dollar ceiling so a runaway job can't drain your account, and
 no session file written to disk. Drop the `--max-*` flags if you trust
 the prompt, swap `bypassPermissions` for `auto` if you want the


### PR DESCRIPTION
## Summary

- Replaces the trailing \`Then run it, for example\` stub in the headless/k8s section with an actual example.
- Shows the two halves: one-time \`claude setup-token\` on a dev box, then a runtime \`claude -p\` invocation reading \`CLAUDE_CODE_OAUTH_TOKEN\` from a secret.
- Demonstrates a bounded run: \`--output-format json\`, \`--max-turns 10\`, \`--max-budget-usd 2.00\`, \`--no-session-persistence\`, \`--permission-mode bypassPermissions\`.
- Adds a short paragraph explaining when to drop the caps or swap permission modes.

## Test plan

- [x] Dev server render verified via Playwright MCP — bash highlighting renders, prose paragraph follows the code block cleanly
- [ ] Kyle: skim before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude code cheat sheet with improved Kubernetes CronJob setup examples
  * Added Dockerfile installation instructions
  * Enhanced run command documentation with detailed parameter explanations
  * Added guidance on permission modes for tool call security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->