### PR TITLE
blog: fix cheat-sheet post dates

### DIFF
--- a/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
+++ b/apps/blog/blog/markdown/posts/claude-code-cheat-sheet.md
@@ -4,8 +4,8 @@ summary: A deeper look into CLI flags, slash commands, keyboard shortcuts, hooks
 slug: claude-code-cheat-sheet
 category: ai
 tags: Claude-Code, AI, reference, CLI
-date: 2026-04-19
-modified: 2026-04-19
+date: 2026-04-27
+modified: 2026-04-27
 status: published
 image: claude-code-cheat-sheet.png
 thumbnail: claude-code-cheat-sheet-thumb.png


### PR DESCRIPTION
## Summary

- Update \`date\` and \`modified\` in \`claude-code-cheat-sheet.md\` from \`2026-04-19\` to \`2026-04-27\` so the post shows the correct publish date in feeds and the sitemap.

## Test plan

- [x] Frontmatter only, no content changes
- [ ] Kyle: confirm before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated blog post metadata timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->