### PR TITLE
seo-bot: fix title typo and keyword alignment for docker-shared-memory

### DIFF
--- a/apps/blog/blog/markdown/posts/docker-shared-memory.md
+++ b/apps/blog/blog/markdown/posts/docker-shared-memory.md
@@ -1,15 +1,18 @@
 ---
-title: Docker Shared Memory (/dev/sdh)
-summary: "Docker's 64MB /dev/shm default is tiny. Raise it per-container with --shm-size, set a daemon-wide default in daemon.json, or remount /dev/shm on the host."
+title: "Docker Shared Memory: 64MB /dev/shm Default and --shm-size"
+summary: "Docker's default /dev/shm size is 64MB. Raise it per-container with --shm-size, set a daemon-wide default in daemon.json, or remount /dev/shm on the host."
 slug: docker-shared-memory
 category: development
 tags: Docker
 date: 2019-09-06
-modified: 2019-09-06
+modified: 2026-05-03
 status: published
 image: Docker.png
 thumbnail: docker-thumb.png
 keywords:
+  - docker default /dev/shm 64mb
+  - docker --shm-size default 64m
+  - docker shm size default
   - docker shared memory size
   - docker shm-size increase
   - docker dev shm too small
@@ -18,7 +21,8 @@ keywords:
 ---
 
 
-Docker supports shared memory. The default is only 64MB though which is TINY.
+Docker supports shared memory. The default /dev/shm size is only 64MB, which is
+tiny for anything doing serious IPC or running Chromium-based tools.
 
 The small size became a problem during a containerized OpenStack upgrade.
 


### PR DESCRIPTION
## Data

GSC (Apr 5–Apr 30 2026): `/docker-shared-memory.html` has **93 impressions, 0 clicks, avg position 16.6**.

The dominant query cluster (22 distinct queries) is entirely about "docker default /dev/shm 64mb" and "--shm-size". Top queries by impression:
- "docker default /dev/shm 64mb" — 5 imp, pos 9.4
- "docker default /dev/shm size 64mb" — 5 imp, pos 8.8
- "docker default /dev/shm size 64mb --shm-size" — 3 imp, pos 10.0

## Problems fixed

1. **Title typo**: The title said `/dev/sdh` — a typo for `/dev/shm`. This directly weakens relevance signals for every query that includes `/dev/shm`.
2. **Title mismatch**: "Docker Shared Memory" is too generic. None of the search queries match it well. The dominant intent is specifically "what is the default 64MB limit and how do I change it with --shm-size".
3. **Missing keywords**: The keywords list had no "docker default /dev/shm 64mb", "--shm-size default 64m", or "docker shm size default" — the actual query terms driving impressions.

## Changes

- Title: `Docker Shared Memory (/dev/sdh)` → `"Docker Shared Memory: 64MB /dev/shm Default and --shm-size"`
- Summary: minor reword to open with "default /dev/shm size is 64MB" (searcher-first framing)
- Keywords: added `docker default /dev/shm 64mb`, `docker --shm-size default 64m`, `docker shm size default`
- Body: reworded the opening sentence to state the 64MB default explicitly (it was only in the summary before)
- `modified` date updated to today

## Expected impact

The page is already ranking (avg pos 16.6, some queries at 8–11). Fixing the title typo and matching the title to actual query language should improve CTR from 0%. Even a 2–3% CTR would yield ~2 clicks/month from this traffic. Relevance alignment may also nudge positions up slightly.

Linear: https://linear.app/pericak/issue/PER-87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker shared memory blog post with expanded introduction explaining the 64MB default and revised metadata, including refreshed keywords for better discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->