### PR TITLE
PER-135: Blog redesign — agent-native design system (research + PRD + design doc)

### DIFF
--- a/apps/blog/blog/markdown/wiki/design-docs/blog-design-system.md
+++ b/apps/blog/blog/markdown/wiki/design-docs/blog-design-system.md
@@ -1,0 +1,405 @@
+---
+title: "Blog Redesign: Agent-Native Design System — Design Doc"
+summary: "Token-driven design system on the existing Next.js 15 Pages Router static export: Tailwind v4 @theme as the token source of truth, Radix + shadcn owned components in TSX, Storybook 10 as the workshop/docs/visual-test surface, dark mode by token swap, and an autonomous verification gate — replacing MUI/Emotion/styled-components/dead-Tailwind-v3."
+status: draft
+owner: kyle
+date: 2026-06-13
+prd: wiki/prds/blog-design-system
+hidden: false
+related:
+  - wiki/prds/blog-design-system
+  - wiki/research/design-system
+  - https://linear.app/pericak/issue/PER-135/blog-redesign-agent-native-design-system
+---
+
+## Context
+
+Link to PRD: [Blog Redesign: Agent-Native Design System](../prds/blog-design-system.html)
+
+The blog (`apps/blog/blog/`) is a Next.js 15.5.12 Pages Router app with
+`output: 'export'` (fully static, deployed to GCS via Cloud Build). The
+technically interesting and risky part of this work is **not** building a
+design system from scratch — it is layering a coherent, token-driven,
+agent-maintainable system onto a live static site that currently runs
+**three overlapping styling stacks** (MUI 5 + Emotion as the real one;
+`tailwindcss@3.3` installed but inert because its `content` globs point at
+a non-existent `./src/**`; `styled-components@6` as dead weight) **without
+a flag-day rewrite**, and doing the migration mostly through agents whose
+only safety net is a machine-checkable verification gate.
+
+Two hard constraints shape every decision below:
+
+1. **`output: 'export'`** — no server runtime. Theming (dark mode) must
+   be a client-side CSS-variable swap with a no-flash inline script, not a
+   server decision. Next.js rewrites are dev-only (already true in
+   `next.config.js` for the `.html` link convention).
+2. **Static-content performance** — the payoff of leaving CSS-in-JS
+   (MUI/Emotion runtime) for Tailwind's zero-runtime CSS variables is real
+   on a content site; it is a goal, not incidental.
+
+## Goals and Non-Goals
+
+**Goals (technical, derived from the PRD):**
+- One token source of truth → CSS variables consumed everywhere; zero raw
+  hex / raw px (except `0`/`1px`) in component code.
+- Tailwind (upgraded to v4, correctly wired) as the styling layer.
+- An owned, readable, accessible component library covering the blog's
+  real surface, authored in TypeScript (`.tsx`).
+- Storybook 10 as the component workshop, documentation surface, and host
+  for visual + a11y tests.
+- Dark mode by token swap, no flash, no layout shift.
+- A `bin/verify-design-system.sh` gate (build + lint + Storybook build +
+  Playwright/axe) that lets agents self-verify before opening PRs.
+- End state: MUI, Emotion, styled-components, and the dead Tailwind v3
+  config fully removed.
+
+**Non-Goals:**
+- No App Router / SSR / re-platform; stay Pages Router + static export.
+- No change to the markdown→remark→HTML authoring pipeline or Prism
+  highlighting (only the *rendered* output is restyled, via `<Prose>`).
+- No forced full-repo TS migration; legacy `pages/*.js` stay JS except
+  where a component swap touches them.
+- No public component registry / npm package in v1.
+- No React 19 bump *required* (see Alternatives); stay on React 18 unless
+  a blocker forces it.
+
+## Proposed Design
+
+A four-layer system plus an autonomy harness, all living under
+`apps/blog/blog/` next to the existing app.
+
+```mermaid
+graph TD
+    subgraph Source of truth
+        T[design-system/tokens.css<br/>@theme: color/space/type/radius/shadow]
+    end
+    subgraph Styling
+        TW[Tailwind v4<br/>utilities from @theme vars]
+        GL[public/css/globals.css<br/>+ Prose base styles]
+    end
+    subgraph Primitives + Components
+        RX[Radix UI primitives]
+        UI[components/ui/*.tsx<br/>shadcn-seeded, owned]
+        PR[primitives: Container/Stack/Grid/Prose]
+        BLOG[blog components:<br/>SiteHeader/PostCard/PostLayout/<br/>CodeBlock/Callout/TagPill/TOC/Pagination]
+    end
+    subgraph Pages
+        P[pages/*.js<br/>index, about, [...route]]
+    end
+    subgraph Docs + Verification
+        SB[Storybook 10<br/>foundations + every component]
+        VG[bin/verify-design-system.sh<br/>build + lint + SB build + Playwright/axe]
+        AG[design-system/AGENTS.md<br/>mirrored via .ruler/]
+    end
+
+    T --> TW
+    T --> GL
+    RX --> UI
+    UI --> BLOG
+    PR --> BLOG
+    TW --> UI
+    TW --> PR
+    BLOG --> P
+    BLOG --> SB
+    PR --> SB
+    T --> SB
+    SB --> VG
+    P --> VG
+    AG -.guides agents.-> UI
+    VG -.gates PRs.-> P
+```
+
+The migration is **additive and page-by-page**: Tailwind v4 and the token
+layer stand up alongside MUI; components are replaced one at a time and
+verified; MUI/Emotion/styled-components are removed only after the last
+usage is gone.
+
+### Component Details
+
+**Token layer** — `apps/blog/blog/design-system/tokens.css`
+- Responsibility: the single source of truth for color, spacing, type
+  scale, radius, shadow, motion, breakpoints, expressed as Tailwind v4
+  `@theme` custom properties (`--color-brand-500`, `--space-4`,
+  `--font-size-lg`, …) using a primitive → semantic two-tier naming
+  (`--color-brand-500` primitive, `--color-text-primary` semantic alias).
+- Seeded by translating the current MUI theme in `pages/_app.js`
+  (`#337ab7` brand blue, `#333333` text, greys) into primitives, then
+  refreshed to a modern palette as part of the visual direction work.
+- Dark mode: a `[data-theme="dark"]` block re-aliases the *semantic*
+  tokens only; primitives and components don't change.
+- Optional `tokens/*.json` (DTCG) export is explicitly **not** load-bearing
+  (see Alternatives) — `tokens.css` is the contract.
+
+**Styling layer** — Tailwind v4
+- `tailwindcss@^4` + `@tailwindcss/postcss`; replace the broken
+  `tailwind.config.ts` with v4 CSS-first config (`@import "tailwindcss";
+  @theme { … }`) imported from `tokens.css`. `@tailwindcss/typography`
+  backs the `<Prose>` wrapper for rendered markdown.
+- `postcss.config.js` updated to the v4 plugin.
+
+**Primitives layer** — Radix UI (`@radix-ui/react-*`)
+- Unstyled, accessible behavior (dialog, dropdown, tooltip, etc.).
+  Supports React 18. Used as the foundation for the owned components.
+
+**Owned component library** — `apps/blog/blog/components/ui/*.tsx`
+- shadcn/ui as the *seed* (`npx shadcn@latest init` → `add <component>`),
+  configured to emit into `components/ui/` and to consume the token CSS
+  variables (not raw Tailwind palette). Components are checked-in `.tsx`
+  files the agents own and edit directly.
+- Layout primitives in `components/primitives/`: `<Container>`,
+  `<Stack>`, `<Cluster>`, `<Grid>`, `<Prose>` (wraps remark HTML; replaces
+  MUI `<Typography>` for post bodies).
+- Blog components in `components/`: `<SiteHeader>`/`<SiteFooter>`/`<NavMenu>`,
+  `<PostCard>`, `<PostLayout>`, `<CodeBlock>` (wraps existing Prism output,
+  adds copy button + language label), `<Callout>`, `<TagPill>`,
+  `<CategoryBadge>`, `<Breadcrumbs>`, `<TableOfContents>`, and a
+  refactored `<Pagination>`. These replace the current `SiteLayout.js`,
+  `IndexPage.js`, `BlogPostContentPage.js`, `BlogSidebar.js`, `WikiPage.js`,
+  `Pagination.js`.
+
+**Documentation + workshop** — Storybook 10 — `apps/blog/blog/.storybook/`
+- `@storybook/nextjs-vite` (Vite builder; independent of the app's webpack
+  build, faster, the current recommended Next.js path). One story per
+  component plus a "Foundations" section rendering the token scales.
+- Hosts the test layer: Storybook test-runner + `@axe-core/playwright` for
+  a11y, and Playwright `toHaveScreenshot()` for visual regression against
+  story canvases (more stable than full-page diffs).
+- `npm run build-storybook` produces the static artifact Kyle demos.
+
+**Dark mode**
+- `data-theme` on `<html>`, set by a tiny blocking inline script in
+  `pages/_document.js` (reads `localStorage`/`prefers-color-scheme` before
+  paint → no flash). A `<ThemeToggle>` flips it. Pure CSS-variable swap;
+  no JS theme provider, compatible with static export.
+
+**Autonomy harness**
+- `apps/blog/bin/verify-design-system.sh`: `next build` (static export
+  succeeds) + `next lint` + `npm run build-storybook` + `npx playwright
+  test` (visual + axe) + a `check-no-raw-hex` grep guard. Exit non-zero
+  fails the agent's PR.
+- `apps/blog/blog/design-system/AGENTS.md`: how to add/change/remove a
+  component and a token; mirrored into `CLAUDE.md`/`.cursor` via a new
+  `.ruler/design-system.md` source.
+
+### Data Model
+
+None. No persistence; tokens and components are source files. The only
+"state" is the dark-mode preference in `localStorage`.
+
+### API / Interface Contracts
+
+- **Token contract:** components reference CSS variables via Tailwind
+  utility classes (`bg-surface`, `text-primary`, `p-4`) that resolve to
+  `@theme` vars. No component hardcodes a hex or px (except `0`/`1px`).
+  Enforced by the grep guard.
+- **`<Prose>` contract:** rendered markdown HTML is injected inside a
+  single `<Prose>` wrapper; markdown element styling lives there, not
+  scattered. Prism markup and classes are preserved; `<CodeBlock>`
+  decorates rather than replaces them.
+- **Story contract:** every component in `components/ui|primitives` and
+  every blog component has a `*.stories.tsx` with at least default + dark
+  variants; the verification gate fails if a component lacks a story
+  (lightweight check).
+
+## Alternatives Considered
+
+### Decision: Styling layer
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| Tailwind v4 (CSS-first `@theme`) | Token source of truth + utilities in one place; zero runtime; mainstream; Kyle wants exposure | New major; must rewire the broken v3 config | **Chosen** — directly serves the token-driven, modern, durable goals |
+| Fix existing Tailwind v3 | Smaller step | No `@theme`; keeps tokens split JS/CSS; aging | Rejected — v3 is already broken and dated |
+| Keep MUI + Emotion | No migration | CSS-in-JS runtime on a static site; not the modern pick; opaque to agents | Rejected — it's the thing being replaced |
+
+### Decision: Token source of truth (addresses Kyle's "DTCG is young" concern)
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| Tailwind `@theme` (`tokens.css`) is load-bearing; DTCG optional | Stable, mainstream, no young-spec risk; one file an agent edits | Not a tool-neutral interchange format | **Chosen** — removes the risk Kyle flagged while keeping a real token layer |
+| DTCG JSON + Style Dictionary as source | Tool-neutral, Figma bridge | Spec is young (first stable 2025.10), Style Dictionary lacks full support; extra build step | Rejected for v1 — kept as optional export only |
+
+### Decision: Primitive + component model (addresses Kyle's "shadcn = you own maintenance" concern)
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| Radix + shadcn-seeded owned `.tsx`, **kept small & Storybook-documented** | Agents read/edit real files; AI-native; no opaque upgrades; the demo Kyle wants | You own upstream fixes | **Chosen** — small surface + Storybook + AGENTS.md is exactly what makes "maintain via AI" cheap |
+| Versioned library (MUI Joy / Radix Themes / Park UI) | `npm`-upgradeable | Opaque to agents; theming fights the token layer; less to "show" as *your* system | Rejected — undercuts the demoable-POC goal |
+| React Aria Components | Deepest a11y | Heavier API, more code; overkill for a blog | Rejected — Radix is sufficient |
+
+### Decision: Storybook (Kyle hard-requirement; overrides the seed research)
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| Storybook 10 (`@storybook/nextjs-vite`) | Industry-standard workshop + docs + test host; Kyle wants exposure; the demo surface; slim modern install | Second build pipeline to maintain | **Chosen** — the seed research argued against it, but it is a stated outcome and *is* the component-library showcase |
+| Bespoke `/design-system` Next route | No new dep | Reinvents Storybook badly; not what a reviewer expects to see | Rejected — Kyle explicitly wants Storybook |
+
+### Decision: Dark mode under static export
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| `data-theme` + no-flash inline script + CSS-var swap | Works with `output: 'export'`; no flash; no provider | Tiny inline script in `_document.js` | **Chosen** |
+| MUI/JS theme provider | Familiar | CSS-in-JS runtime; flash risk on static; being removed anyway | Rejected |
+
+### Decision: TypeScript depth
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| New DS code in `.tsx`, legacy pages stay `.js` | Tooling already present (`typescript@5`, TS configs); shadcn/Storybook are TS-first; modern signal | Mixed JS/TS repo during transition | **Chosen** |
+| Convert whole blog to TS | Uniform | Large, out-of-scope, risky | Rejected — explicit non-goal |
+| Stay all-JS | No new surface | Fights shadcn/Storybook defaults; weaker demo | Rejected |
+
+## File Change List
+
+| Action | File | Rationale |
+|--------|------|-----------|
+| CREATE | `apps/blog/blog/design-system/tokens.css` | Token source of truth (`@theme` CSS vars, light + `[data-theme=dark]`) |
+| CREATE | `apps/blog/blog/design-system/AGENTS.md` | Agent instructions: add/change/remove component or token |
+| CREATE | `apps/blog/blog/design-system/INVENTORY.md` | Phase-0 map of existing components + every MUI/styled-components usage |
+| CREATE | `apps/blog/blog/components/ui/*.tsx` | shadcn-seeded owned primitives (Button, Dialog, etc.) |
+| CREATE | `apps/blog/blog/components/primitives/{Container,Stack,Cluster,Grid,Prose}.tsx` | Layout primitives; `<Prose>` wraps rendered markdown |
+| CREATE | `apps/blog/blog/components/{SiteHeader,SiteFooter,NavMenu,PostCard,PostLayout,CodeBlock,Callout,TagPill,CategoryBadge,Breadcrumbs,TableOfContents,ThemeToggle}.tsx` | Blog component library |
+| CREATE | `apps/blog/blog/**/*.stories.tsx` | One story per component + Foundations |
+| CREATE | `apps/blog/blog/.storybook/{main.ts,preview.ts}` | Storybook 10 config (nextjs-vite, dark backgrounds, a11y addon) |
+| CREATE | `apps/blog/bin/verify-design-system.sh` | Autonomy gate: build + lint + SB build + Playwright/axe + hex guard |
+| CREATE | `apps/blog/blog/scripts/check-no-raw-hex.mjs` | Grep guard: no raw hex/px in component code |
+| CREATE | `.ruler/design-system.md` | Ruler source → fans DS rules into CLAUDE.md/.cursor |
+| MODIFY | `apps/blog/blog/package.json` | Add tailwind@4, @tailwindcss/postcss+typography, radix, storybook 10, axe; remove mui/emotion/styled-components/tailwind@3 (last) |
+| MODIFY | `apps/blog/blog/postcss.config.js` | Tailwind v4 PostCSS plugin |
+| DELETE | `apps/blog/blog/tailwind.config.ts` | Broken v3 config replaced by v4 CSS-first `@theme` |
+| MODIFY | `apps/blog/blog/pages/_app.js` | Remove MUI ThemeProvider/createTheme; import token CSS; keep GA |
+| MODIFY | `apps/blog/blog/pages/_document.js` | No-flash dark-mode inline script; `data-theme` bootstrap |
+| MODIFY | `apps/blog/blog/pages/{index,about,[...route]}.js` | Swap MUI components for the new library, page by page |
+| MODIFY | `apps/blog/blog/public/css/globals.css` | Token-backed base styles; `<Prose>` typography |
+| MODIFY | `apps/blog/blog/playwright.config.ts` | Add story-canvas visual + axe projects |
+| DELETE | `apps/blog/blog/components/{SiteLayout,IndexPage,BlogPostContentPage,BlogSidebar,WikiPage,Pagination}.js` | Superseded by the new library (after migration) |
+
+## Task Breakdown
+
+Dependency-ordered. Each task is one coherent, isolated-testable change
+sized for a single Claude Code session / autolearn pick-up. `[P]` =
+parallelizable with its siblings. Every task ends green on the relevant
+slice of `verify-design-system.sh`.
+
+### TASK-001: Inventory + visual direction
+
+- **Requirement:** PRD "demos to experts" + open question "how redesigned?"
+- **Files:** `apps/blog/blog/design-system/INVENTORY.md`
+- **Dependencies:** None
+- **Acceptance criteria:**
+  - [ ] Every component, page, and MUI/styled-components usage listed with paths.
+  - [ ] 2–3 visual directions (palette + type + spacing) proposed as a short doc / mockup for Kyle to choose before mass component work.
+
+### TASK-002: Stand up Tailwind v4 alongside MUI
+
+- **Requirement:** PRD success metric 1 (styling layer)
+- **Files:** `package.json`, `postcss.config.js`, `tailwind.config.ts` (delete), `design-system/tokens.css`, `public/css/globals.css`
+- **Dependencies:** TASK-001
+- **Acceptance criteria:**
+  - [ ] `tailwindcss@4` + `@tailwindcss/postcss` installed and compiling; broken v3 config removed.
+  - [ ] An empty/seed `@theme` renders; `next build` static export still succeeds; nothing visually changes yet.
+
+### TASK-003: Token foundation
+
+- **Requirement:** PRD success metric 1 (single source of truth)
+- **Files:** `design-system/tokens.css`
+- **Dependencies:** TASK-002
+- **Acceptance criteria:**
+  - [ ] Color/space/type/radius/shadow tokens defined as `@theme` vars (primitive + semantic tiers), seeded from the current MUI theme then refreshed per the chosen direction.
+  - [ ] `[data-theme="dark"]` re-aliases semantic tokens; both themes render in a scratch page.
+
+### TASK-004: Storybook 10 install + Foundations story
+
+- **Requirement:** PRD "demonstrable component library" `[P]`
+- **Files:** `.storybook/main.ts`, `.storybook/preview.ts`, `package.json`, `design-system/Foundations.stories.tsx`
+- **Dependencies:** TASK-003
+- **Acceptance criteria:**
+  - [ ] `npm run storybook` runs; `npm run build-storybook` produces a static build.
+  - [ ] A Foundations story renders the token scales in light + dark.
+
+### TASK-005: shadcn init + first owned primitive `[P]`
+
+- **Requirement:** PRD "future change is straightforward through AI"
+- **Files:** `components.json`, `components/ui/button.tsx`, `button.stories.tsx`
+- **Dependencies:** TASK-003
+- **Acceptance criteria:**
+  - [ ] `shadcn` initialized to emit into `components/ui/`, wired to token vars (no raw palette classes).
+  - [ ] `<Button>` renders in Storybook; one MUI button call site swapped as a pilot and verified via Playwright MCP.
+
+### TASK-006: Layout primitives + `<Prose>`
+
+- **Requirement:** PRD readability / `<Prose>` contract
+- **Files:** `components/primitives/{Container,Stack,Cluster,Grid,Prose}.tsx` + stories
+- **Dependencies:** TASK-003
+- **Acceptance criteria:**
+  - [ ] Primitives render token-driven; `<Prose>` styles a sample rendered-markdown blob (incl. Prism code) with no MUI.
+
+### TASK-007: Dark-mode plumbing
+
+- **Requirement:** PRD "modern, nicer" + dark mode
+- **Files:** `pages/_document.js`, `components/ThemeToggle.tsx` + story
+- **Dependencies:** TASK-003
+- **Acceptance criteria:**
+  - [ ] No-flash inline script sets `data-theme` from storage/`prefers-color-scheme` before paint.
+  - [ ] Toggle flips theme with no layout shift; Playwright confirms both themes.
+
+### TASK-008: Verification gate + Ruler docs
+
+- **Requirement:** PRD autonomy / verification gate (land before mass migration)
+- **Files:** `apps/blog/bin/verify-design-system.sh`, `scripts/check-no-raw-hex.mjs`, `playwright.config.ts`, `design-system/AGENTS.md`, `.ruler/design-system.md`
+- **Dependencies:** TASK-004, TASK-005, TASK-006
+- **Acceptance criteria:**
+  - [ ] Gate runs build + lint + storybook build + Playwright(visual+axe) + hex guard and exits non-zero on any failure.
+  - [ ] `AGENTS.md` documents add/change/remove flows; `ruler apply` fans the rules into CLAUDE.md.
+
+### TASK-009 … 013: Blog component build + page migration `[P per page]`
+
+- **Requirement:** PRD "visibly modern blog" + metric 1
+- **Files:** `components/{SiteHeader,SiteFooter,NavMenu,PostCard,PostLayout,CodeBlock,Callout,TagPill,CategoryBadge,Breadcrumbs,TableOfContents}.tsx` + stories; `pages/{index,about,[...route]}.js`; delete old `components/*.js`
+- **Dependencies:** TASK-008 (gate must exist first)
+- **Acceptance criteria (per page):**
+  - [ ] Page uses only the new library; its MUI/styled-components imports are gone; each new component has a story.
+  - [ ] `verify-design-system.sh` is green; Playwright MCP screenshots at mobile/tablet/desktop match the chosen direction.
+
+### TASK-014: Remove MUI / Emotion / styled-components (last)
+
+- **Requirement:** PRD success metric 1 (full removal)
+- **Files:** `package.json`, `pages/_app.js`
+- **Dependencies:** TASK-009–013 all done
+- **Acceptance criteria:**
+  - [ ] `rg "@mui|@emotion|styled-components" apps/blog/blog --files-with-matches` returns nothing.
+  - [ ] Packages uninstalled; `next build` + full gate green; bundle size delta recorded.
+
+## Implementation Additions
+
+_(none yet — populated as scope drifts during implementation)_
+
+## Open Questions
+
+- **Visual direction** — blocks TASK-009+ mass work. Resolved by Kyle
+  picking one of the TASK-001 directions.
+- **Component model confirmation** — shadcn-owned vs. versioned library
+  (PRD open question). Default proceeds with shadcn-owned; a reversal
+  before TASK-005 is cheap, expensive after.
+- **React 18 vs 19** — shadcn's latest targets React 19; components work
+  on 18 via Radix, but if a specific component needs 19, that's a
+  go/no-go on a small React bump. Blocks only the component(s) that hit it.
+- **Autonomy routing** — should TASK-002…014 become individual Linear
+  sub-issues under PER-135 with the `autolearn` label so the pipeline
+  executes them, or run as Claude Code sessions Kyle kicks off? Blocks how
+  "hands-off" execution actually is.
+
+## Risks
+
+- **Mid-migration bundle bloat** (MUI + Tailwind coexisting). Accepted;
+  recovered at TASK-014. Mitigation: remove old system last, record delta.
+- **Noisy visual regression.** Mitigation: diff Storybook story canvases
+  (isolated) not full pages; run in the Docker/Cloud Build environment;
+  set `maxDiffPixelRatio` thresholds.
+- **Static-export dark-mode flash.** Mitigation: blocking inline script in
+  `_document.js` before first paint.
+- **Weak gate → autonomous regressions.** Mitigation: gate is TASK-008,
+  landed and proven before any mass page migration.
+- **shadcn/React-19 assumptions.** Mitigation: pin component versions;
+  treat the React bump as an isolated, reversible decision if forced.
+- **Scope creep toward a full TS/App-Router rewrite.** Mitigation: tasks
+  are additive; the non-goals are explicit and enforced in review.

--- a/apps/blog/blog/markdown/wiki/design-docs/blog-design-system.md
+++ b/apps/blog/blog/markdown/wiki/design-docs/blog-design-system.md
@@ -60,8 +60,8 @@ Two hard constraints shape every decision below:
 - No forced full-repo TS migration; legacy `pages/*.js` stay JS except
   where a component swap touches them.
 - No public component registry / npm package in v1.
-- No React 19 bump *required* (see Alternatives); stay on React 18 unless
-  a blocker forces it.
+- React **18 → 19** upgrade *is* in scope (Kyle: bias to newest); it is
+  the one framework-version bump. Still no App Router / SSR / re-platform.
 
 ## Proposed Design
 
@@ -139,7 +139,7 @@ usage is gone.
 
 **Primitives layer** — Radix UI (`@radix-ui/react-*`)
 - Unstyled, accessible behavior (dialog, dropdown, tooltip, etc.).
-  Supports React 18. Used as the foundation for the owned components.
+  Radix supports React 19. Used as the foundation for the owned components.
 
 **Owned component library** — `apps/blog/blog/components/ui/*.tsx`
 - shadcn/ui as the *seed* (`npx shadcn@latest init` → `add <component>`),
@@ -276,18 +276,27 @@ None. No persistence; tokens and components are source files. The only
 ## Task Breakdown
 
 Dependency-ordered. Each task is one coherent, isolated-testable change
-sized for a single Claude Code session / autolearn pick-up. `[P]` =
+sized for a single Claude Code `/goal`-driven turn. `[P]` =
 parallelizable with its siblings. Every task ends green on the relevant
 slice of `verify-design-system.sh`.
 
 ### TASK-001: Inventory + visual direction
 
-- **Requirement:** PRD "demos to experts" + open question "how redesigned?"
+- **Requirement:** PRD "demos to experts" + the visual-direction gate
 - **Files:** `apps/blog/blog/design-system/INVENTORY.md`
 - **Dependencies:** None
 - **Acceptance criteria:**
   - [ ] Every component, page, and MUI/styled-components usage listed with paths.
-  - [ ] 2–3 visual directions (palette + type + spacing) proposed as a short doc / mockup for Kyle to choose before mass component work.
+  - [ ] **3** visual directions (palette + type + spacing) proposed as mockups for Kyle to choose before mass component work.
+
+### TASK-001B: Upgrade React 18 → 19 `[P]`
+
+- **Requirement:** "bias to newest" decision; shadcn/ui targets React 19
+- **Files:** `package.json` (`react`, `react-dom`, `@types/react*`)
+- **Dependencies:** None
+- **Acceptance criteria:**
+  - [ ] React 19 + matching types installed; `next build` static export succeeds; existing pages render unchanged (Playwright smoke).
+  - [ ] Any peer-dep breakage resolved or recorded; isolated commit, easy to revert.
 
 ### TASK-002: Stand up Tailwind v4 alongside MUI
 
@@ -375,18 +384,12 @@ _(none yet — populated as scope drifts during implementation)_
 
 ## Open Questions
 
-- **Visual direction** — blocks TASK-009+ mass work. Resolved by Kyle
-  picking one of the TASK-001 directions.
-- **Component model confirmation** — shadcn-owned vs. versioned library
-  (PRD open question). Default proceeds with shadcn-owned; a reversal
-  before TASK-005 is cheap, expensive after.
-- **React 18 vs 19** — shadcn's latest targets React 19; components work
-  on 18 via Radix, but if a specific component needs 19, that's a
-  go/no-go on a small React bump. Blocks only the component(s) that hit it.
-- **Autonomy routing** — should TASK-002…014 become individual Linear
-  sub-issues under PER-135 with the `autolearn` label so the pipeline
-  executes them, or run as Claude Code sessions Kyle kicks off? Blocks how
-  "hands-off" execution actually is.
+- **Visual direction** — the one remaining human gate. Blocks TASK-009+
+  mass work until Kyle picks one of the three TASK-001B mockups. Everything
+  before it (foundations, React 19, tooling, gate) runs without it.
+
+Resolved (2026-06-13): component model = shadcn-owned `.tsx`; React = 19;
+autonomy = a `/goal` session (not `autolearn` Linear sub-issues).
 
 ## Risks
 
@@ -399,7 +402,9 @@ _(none yet — populated as scope drifts during implementation)_
   `_document.js` before first paint.
 - **Weak gate → autonomous regressions.** Mitigation: gate is TASK-008,
   landed and proven before any mass page migration.
-- **shadcn/React-19 assumptions.** Mitigation: pin component versions;
-  treat the React bump as an isolated, reversible decision if forced.
+- **React 19 ecosystem maturity.** Upgrading to React 19 (TASK-001B) can
+  surface peer-dep warnings or a lib not yet on 19. Mitigation: do the bump
+  early and isolated; `mermaid`/`openai`/`sharp` are runtime-agnostic; pin
+  versions and verify `next build` before any component work.
 - **Scope creep toward a full TS/App-Router rewrite.** Mitigation: tasks
   are additive; the non-goals are explicit and enforced in review.

--- a/apps/blog/blog/markdown/wiki/design-docs/index.md
+++ b/apps/blog/blog/markdown/wiki/design-docs/index.md
@@ -37,3 +37,4 @@ section feeds directly into Claude Code's plan mode for implementation.
 - [Autonomous Security Improvement Loop](security-improvement-loop.html) — Bash wrapper invoking Claude Code for iterative Mac workstation hardening with adversarial verification (draft, 2026-03-18)
 - [Security Improvement Log](security-improvement-log.html) — Structured log of autonomous security improvements
 - [Pai Improvements](pai-improvements.html) — Markdown-backed memory MCP, active recall via pai-recaller sub-agent, 1-min commitment scheduler, browser automation. Single-user Discord assistant on Claude Max OAuth (draft, 2026-05-08)
+- [Blog Redesign: Agent-Native Design System](blog-design-system.html) — Token-driven Tailwind v4 `@theme` system, Radix + shadcn owned components in TSX, Storybook 10 workshop/docs/visual-tests, dark mode by token swap, autonomous verification gate; replaces MUI/Emotion/styled-components (draft, 2026-06-13)

--- a/apps/blog/blog/markdown/wiki/prds/blog-design-system.md
+++ b/apps/blog/blog/markdown/wiki/prds/blog-design-system.md
@@ -1,0 +1,227 @@
+---
+title: "Blog Redesign: Agent-Native Design System"
+summary: "A modern, demonstrable design system for kyle.pericak.com — token-driven theming, a real component library, Tailwind + Storybook, built and maintained mostly autonomously by the agent team."
+status: draft
+owner: kyle
+date: 2026-06-13
+hidden: false
+related:
+  - wiki/design-docs/blog-design-system
+  - wiki/research/design-system
+  - https://linear.app/pericak/issue/PER-135/blog-redesign-agent-native-design-system
+---
+
+## Problem
+
+kyle.pericak.com works but looks dated and is built on an incoherent
+styling foundation. Verified from the repo (`apps/blog/blog/`):
+
+- **Three styling systems coexist.** Material UI 5 + Emotion is the real
+  one (a `createTheme` in `pages/_app.js` with bespoke typography
+  variants and four hardcoded hex colors). On top of that, `tailwindcss@3.3`
+  is installed but **inert** — `tailwind.config.ts` scans `./src/**`
+  globs that don't exist, so it emits no utilities — and
+  `styled-components@6` sits in `dependencies` as further dead weight.
+- **No design tokens.** Colors are hardcoded hex (`#337ab7`, `#333333`,
+  …) inside the MUI theme. There is no single source of truth; changing
+  the brand color means hunting through `sx` props and `_app.js`.
+- **No dark mode.** Single light theme only.
+- **No component library or component documentation.** Six ad-hoc
+  components (`SiteLayout`, `IndexPage`, `BlogPostContentPage`,
+  `BlogSidebar`, `WikiPage`, `Pagination`) with styling inline via `sx`.
+  Nothing renders a component in isolation; there is no catalogue.
+- **Visual quality is "2014 Bootstrap."** The look does not represent
+  the technical sophistication of the content or the agent tooling
+  behind it.
+
+The blog is the public face of a heavily AI-native engineering practice.
+Right now the *content* demonstrates that sophistication and the *design*
+undercuts it. Kyle wants the design to become a showpiece in its own
+right — something he can put in front of other full-stack experts as a
+proof of how a small team (one human + an agent fleet) builds a
+first-class, modern frontend.
+
+## Goal
+
+Give the blog a clearly-defined, modern, demonstrable design system —
+token-driven, documented in a real component library, built on
+mainstream building blocks chosen to last 3–5+ years — and ship a
+visibly nicer redesign on top of it, executed mostly autonomously by
+the agent team.
+
+## Success Metrics
+
+1. **Single source of visual truth:** 100% of the redesigned UI's
+   colors, spacing, type, radius, and shadows resolve to named design
+   tokens. A grep guard finds zero raw hex / raw px (except `0`/`1px`)
+   in component code. MUI, Emotion, dead Tailwind v3, and
+   styled-components are fully removed from `dependencies`.
+2. **Demonstrable component library:** Every shipped component has a
+   Storybook story showing its canonical states; the static Storybook
+   builds clean and is the artifact Kyle shows other engineers.
+3. **Autonomy:** ≥80% of the implementation tasks (by task count in the
+   design doc) are completed by the agent pipeline / Claude Code
+   sessions with Kyle reviewing PRs rather than writing code.
+4. **Quality bar held:** Lighthouse/axe accessibility ≥ the current
+   site on every redesigned page (target: zero serious/critical axe
+   violations), and the production static export still builds and
+   deploys unchanged.
+
+## Non-Goals
+
+- **Not a framework migration.** Stay on Next.js 15 Pages Router with
+  `output: 'export'`. No App Router, no SSR, no re-platform.
+- **Not a content migration.** The markdown posts, the remark→HTML
+  pipeline, Prism syntax highlighting, and the `.html` internal-link
+  convention stay as-is. The design system styles the *rendered* output;
+  it does not change how posts are authored.
+- **Not a full TypeScript migration of the blog.** New design-system
+  code is authored in TypeScript (the tooling is already present), but
+  legacy `pages/*.js` are not force-converted beyond what a component
+  swap requires.
+- **Not a rebrand of identity** (logo, name, voice). This is a visual
+  system refresh, not a brand exercise — though a refreshed, tokenized
+  color palette and type scale are in scope.
+- **Not a public component registry / npm package** in v1. The library
+  is internal to `apps/blog`. (Publishing a `shadcn`-compatible registry
+  is a noted future option, not a v1 deliverable.)
+
+## User Stories
+
+### Story: Kyle demos the design system to other full-stack experts
+
+As the blog's owner, I want a browsable component library with a
+documented token system, so that I can show another senior engineer
+"here's the design system" and have it stand up to scrutiny.
+
+**Acceptance criteria:**
+- [ ] A Storybook instance renders every component in its canonical
+  states (default, variants, dark mode), buildable with one command and
+  as a static site.
+- [ ] Tokens (color, space, type, radius, shadow) are visible and
+  documented — a "foundations" section in Storybook plus the token
+  source files.
+- [ ] The stack is composed of named, mainstream tools a reviewer would
+  recognize as current best practice (Tailwind, Storybook, an
+  accessible primitive layer, a token pipeline).
+
+### Story: Kyle gets a visibly modern, nicer-looking blog
+
+As a reader-facing outcome, I want the blog to look modern and polished,
+so that the design matches the sophistication of the content.
+
+**Acceptance criteria:**
+- [ ] Home, post, wiki, and about pages are visually refreshed against
+  the new token system (improved type scale, spacing rhythm, color, and
+  component polish).
+- [ ] Dark mode is supported and toggles without a flash or layout shift.
+- [ ] Redesigned pages are responsive and verified at mobile / tablet /
+  desktop breakpoints via the Playwright MCP screenshot loop.
+
+### Story: The agent team builds and maintains it with Kyle mostly out of the loop
+
+As the operator of an agent fleet, I want the redesign executed and
+maintained primarily by agents, so that I review and steer rather than
+hand-code.
+
+**Acceptance criteria:**
+- [ ] The work is decomposed into dependency-ordered tasks (in the
+  design doc) that the autolearn pipeline / Claude Code can pick up and
+  execute one at a time.
+- [ ] A machine-checkable verification gate (`bin/verify-design-system.sh`
+  or equivalent: build + lint + Storybook build + Playwright/axe) lets
+  an agent self-verify a change before opening a PR.
+- [ ] A short `apps/blog/design-system/AGENTS.md` (mirrored through
+  `.ruler/`) tells any agent how to add, change, or remove a component
+  so future maintenance is "ask an agent," not "relearn the system."
+
+### Story: A future component change is straightforward through AI
+
+As the maintainer, I want adding or changing a component to be a simple,
+well-paved request to an agent, so that maintenance stays cheap.
+
+**Acceptance criteria:**
+- [ ] Component source lives as readable, checked-in files (not opaque
+  `node_modules`), so an agent can open and edit them directly.
+- [ ] There is a documented, repeatable path ("add a component", "change
+  a token") an agent can follow end to end, ending in a green
+  verification gate.
+
+## Scope
+
+**In scope (v1):**
+- A token layer (color, spacing, typography, radius, shadow, breakpoints)
+  as the single source of truth, surfaced as CSS variables.
+- Tailwind (upgraded and correctly wired) as the styling layer consuming
+  those tokens.
+- An accessible component library covering the blog's real surface:
+  layout primitives, site header/footer/nav, post card + post layout,
+  code block, callout, tag/category, pagination, breadcrumbs, table of
+  contents, and markdown element styling (the `<Prose>` wrapper).
+- Storybook as the component workshop, documentation surface, and visual
+  + a11y test host.
+- Dark mode via token swap.
+- Full removal of MUI, Emotion, dead Tailwind v3 config, and
+  styled-components by the end.
+- Agent-facing docs + a verification gate that make the system
+  autonomously buildable and maintainable.
+
+**Deferred:**
+- Publishing a public/shared component registry or npm package.
+- Figma / Tokens Studio design-tool integration (only if Kyle starts
+  designing in Figma).
+- Hosted visual-review SaaS (Chromatic) — adopt only if local visual
+  regression proves too noisy at scale.
+- Any redesign of non-blog apps in the monorepo.
+
+## Open Questions
+
+These do not block starting; flagged for Kyle to pick at on review. The
+design doc proposes a default for each.
+
+- **Component model — shadcn/ui vs. a maintained library.** The seed
+  research recommends the shadcn/ui copy-paste model (you own the
+  `.tsx`), which is AI-friendly but means Kyle owns upstream
+  maintenance — a caveat he disliked. Design doc default: **use shadcn/ui
+  as the *starting point* for owned primitives but keep the surface
+  small and Storybook-documented**, which is what makes "maintain via
+  AI" tractable. Alternative to weigh: a versioned library (e.g. MUI
+  Joy / Park UI / Radix Themes) that upgrades via `npm`. *Decision
+  needed from Kyle.*
+- **Token format — DTCG JSON vs. Tailwind `@theme` as source of truth.**
+  Kyle flagged the DTCG spec as "young." Design doc default: **Tailwind
+  v4 `@theme` (or a plain tokens module) is the load-bearing source of
+  truth; DTCG export is optional and non-blocking**, which removes the
+  young-spec risk while keeping a real token layer. *Confirm acceptable.*
+- **TypeScript depth.** Author new DS components in `.tsx` (tooling
+  present) while leaving legacy pages `.js`? Design doc default: **yes.**
+  *Confirm.*
+- **How "redesigned" visually?** Is there a reference aesthetic Kyle
+  wants (e.g. Vercel/Geist, Linear, Stripe-like), or should the agents
+  propose 2–3 directions for him to pick? Design doc default: **agents
+  produce 2–3 visual directions as Storybook mockups for Kyle to choose
+  before mass component work.**
+- **Tailwind v4 vs. fixing v3.** v3 is already a (broken) dep. Design
+  doc default: **upgrade to Tailwind v4** for the `@theme` token model
+  and longevity. *Confirm the upgrade is wanted vs. repairing v3.*
+
+## Risks
+
+- **Three-way styling coexistence inflates the bundle mid-migration.**
+  MUI + Tailwind running together temporarily is expected; the metric
+  (remove MUI/Emotion/styled-components) only lands at the end.
+  Mitigation: page-by-page migration with the old system removed last.
+- **Visual regression is noisy** (anti-aliasing, fonts, emoji across
+  machines). Mitigation: run snapshots in the existing Docker/Cloud
+  Build environment, set diff thresholds, and lean on Storybook's
+  isolated rendering rather than full-page diffs.
+- **`output: 'export'` constraints.** No SSR theming; dark mode must be
+  a no-flash inline script + CSS-variable swap, not a server decision.
+  Mitigation: standard `class`/`data-theme` on `<html>` with a tiny
+  blocking script.
+- **Autonomy depends on a trustworthy gate.** If the verification gate
+  is weak, autonomous PRs ship visual regressions. Mitigation: the gate
+  (build + lint + Storybook build + Playwright/axe) is itself a v1
+  deliverable, landed before mass migration.
+- **Scope creep into a full TS / App Router rewrite.** Explicitly a
+  non-goal; the design doc must keep tasks additive.

--- a/apps/blog/blog/markdown/wiki/prds/blog-design-system.md
+++ b/apps/blog/blog/markdown/wiki/prds/blog-design-system.md
@@ -126,12 +126,12 @@ hand-code.
 
 **Acceptance criteria:**
 - [ ] The work is decomposed into dependency-ordered tasks (in the
-  design doc) that the autolearn pipeline / Claude Code can pick up and
+  design doc) that a Claude Code `/goal` session can pick up and
   execute one at a time.
 - [ ] A machine-checkable verification gate (`bin/verify-design-system.sh`
   or equivalent: build + lint + Storybook build + Playwright/axe) lets
   an agent self-verify a change before opening a PR.
-- [ ] A short `apps/blog/design-system/AGENTS.md` (mirrored through
+- [ ] A short `apps/blog/blog/design-system/AGENTS.md` (mirrored through
   `.ruler/`) tells any agent how to add, change, or remove a component
   so future maintenance is "ask an agent," not "relearn the system."
 
@@ -174,36 +174,31 @@ well-paved request to an agent, so that maintenance stays cheap.
   regression proves too noisy at scale.
 - Any redesign of non-blog apps in the monorepo.
 
+## Decisions (resolved 2026-06-13)
+
+Kyle's calls on the original open questions:
+
+- **Component model: shadcn/ui-seeded owned `.tsx`.** Kept small and
+  Storybook-documented so "maintain via AI" stays tractable. (Not a
+  versioned `npm` library.)
+- **Visual direction: agents generate 3 mockups; Kyle picks one** before
+  mass component work. This is the one intentional human gate.
+- **React: bias to newest → upgrade to React 19** as part of the work
+  (shadcn/ui targets 19; aligns with the "modern, 3–5yr" goal).
+- **TypeScript depth: new DS code in `.tsx`, legacy pages stay `.js`.**
+- **Token format: Tailwind v4 `@theme` is the load-bearing source of
+  truth; DTCG export optional and non-blocking** (removes the young-spec
+  risk Kyle flagged).
+- **Tailwind: upgrade the inert v3 to v4** for the `@theme` token model.
+- **Autonomy routing: a `/goal` session, not `autolearn` Linear
+  sub-issues.** Kyle pastes a goal that drives Claude Code through the
+  design doc's task breakdown until the verification gate is green.
+
 ## Open Questions
 
-These do not block starting; flagged for Kyle to pick at on review. The
-design doc proposes a default for each.
-
-- **Component model — shadcn/ui vs. a maintained library.** The seed
-  research recommends the shadcn/ui copy-paste model (you own the
-  `.tsx`), which is AI-friendly but means Kyle owns upstream
-  maintenance — a caveat he disliked. Design doc default: **use shadcn/ui
-  as the *starting point* for owned primitives but keep the surface
-  small and Storybook-documented**, which is what makes "maintain via
-  AI" tractable. Alternative to weigh: a versioned library (e.g. MUI
-  Joy / Park UI / Radix Themes) that upgrades via `npm`. *Decision
-  needed from Kyle.*
-- **Token format — DTCG JSON vs. Tailwind `@theme` as source of truth.**
-  Kyle flagged the DTCG spec as "young." Design doc default: **Tailwind
-  v4 `@theme` (or a plain tokens module) is the load-bearing source of
-  truth; DTCG export is optional and non-blocking**, which removes the
-  young-spec risk while keeping a real token layer. *Confirm acceptable.*
-- **TypeScript depth.** Author new DS components in `.tsx` (tooling
-  present) while leaving legacy pages `.js`? Design doc default: **yes.**
-  *Confirm.*
-- **How "redesigned" visually?** Is there a reference aesthetic Kyle
-  wants (e.g. Vercel/Geist, Linear, Stripe-like), or should the agents
-  propose 2–3 directions for him to pick? Design doc default: **agents
-  produce 2–3 visual directions as Storybook mockups for Kyle to choose
-  before mass component work.**
-- **Tailwind v4 vs. fixing v3.** v3 is already a (broken) dep. Design
-  doc default: **upgrade to Tailwind v4** for the `@theme` token model
-  and longevity. *Confirm the upgrade is wanted vs. repairing v3.*
+- None blocking. Remaining choices (exact palette/type for the 3 mockups,
+  whether to publish a registry later) are deferred and surface during
+  implementation.
 
 ## Risks
 

--- a/apps/blog/blog/markdown/wiki/prds/index.md
+++ b/apps/blog/blog/markdown/wiki/prds/index.md
@@ -23,3 +23,4 @@ before design docs.
 - [Autonomous Publisher Pipeline](/wiki/prds/autonomous-publisher.html) — Run the full publisher pipeline autonomously in K8s using Claude Max tokens, with self-verification and network isolation. *(done)*
 - [Hardened IaC Bootstrap](/wiki/prds/hardened-iac-bootstrap.html) — Reproducible, Vault-integrated, PSS-enforced IaC for the AI agent K8s stack, bootstrappable from a single script. *(draft)*
 - [Autonomous Security Improvement Loop](/wiki/prds/security-improvement-loop.html) — Iterative autonomous hardening of the Mac workstation's security posture, with cost controls and structured logging. *(draft)*
+- [Blog Redesign: Agent-Native Design System](/wiki/prds/blog-design-system.html) — Token-driven design system and visual redesign for the blog (Tailwind + Storybook + an owned component library), built and maintained mostly autonomously. *(draft)*

--- a/apps/blog/blog/markdown/wiki/research/design-system/claude-report.md
+++ b/apps/blog/blog/markdown/wiki/research/design-system/claude-report.md
@@ -1,0 +1,406 @@
+---
+title: "Claude Deep Research: A Modern, Agent-Native Design System for kyle.pericak.com"
+summary: "Claude Deep Research report on building an additive, agent-readable design system on the existing Next.js + MUI blog stack — design tokens (DTCG/Style Dictionary), Tailwind v4, Radix primitives, the shadcn/ui copy-paste model, MCP-driven workflows, and Playwright/axe visual + a11y guardrails."
+keywords:
+  - deep-research
+  - claude
+  - design-system
+  - design-tokens
+  - tailwind
+  - storybook
+  - shadcn
+  - radix
+  - component-library
+  - blog-redesign
+provider: claude
+prompt: "Research a modern, agent-native design system for kyle.pericak.com as a predicate to a blog redesign: what a design system is, what makes one good, the modern building blocks (tokens, styling, primitives, component model, MCP, LLM-readable docs), and prescriptive guidance for an additive migration off the current Next.js Pages Router + MUI stack."
+date_generated: 2026-05-28
+related:
+  - wiki/research
+  - wiki/research/design-system
+  - wiki/prds/blog-design-system
+scope: "Single-provider Deep Research report. Not cross-referenced or synthesized. Seed input for PER-135 (blog redesign / design system). Kyle's steering overrides parts of it — notably Storybook is in scope despite the report recommending against it."
+last_verified: 2026-05-28
+---
+
+# A Modern, Agent-Native Design System for kyle.pericak.com
+
+**TL;DR**
+- **Build the design system *additively* on top of your existing Next.js (Pages Router, JavaScript) + MUI + remark + Prism stack.** Adopt three industry-standard layers — Tailwind CSS v4 (CSS-first design tokens), Radix UI primitives, and the shadcn/ui copy-paste model — and migrate components one at a time. Don't rewrite; co-exist with MUI until the last `<Typography>` is gone.
+- **Skip Storybook for now.** For a solo blog with ~12 component types, Storybook is overkill; the right "isolated component playground" is a single `/design-system` Next.js route plus Playwright MCP screenshots driven by Claude Code. Adopt Storybook only if/when you publish a public component registry or open up the blog to multiple authors.
+- **Make design tokens the agent-readable contract.** Author tokens in W3C DTCG JSON, compile through Style Dictionary into Tailwind v4 `@theme` CSS variables, document the system in `apps/blog/design-system/AGENTS.md` (mirrored from your existing `.ruler/` source), and run a `/design-token` slash command + Playwright visual diff as the guardrail that lets Pai/Publisher/Reviewer iterate without you in the loop.
+
+---
+
+## 1. What Is a Design System?
+
+A design system is the **single source of truth that turns design decisions into shipped product code**. It is not a Figma file, not a component library, and not a brand guidelines PDF — it is the union of all of those plus the *governance and tooling* that keeps them coherent. The most-cited working definition comes from Nathan Curtis of EightShapes: "A design system isn't a project. It's a product, serving products." Brad Frost's *Atomic Design* (2013, with design tokens added formally in 2019) gave the industry the dominant mental model: subatomic tokens → atoms → molecules → organisms → templates → pages.
+
+### Distinguishing it from related concepts
+
+| Term | What it is | Relationship to a design system |
+|---|---|---|
+| **Style guide** | A document describing visual rules (colors, type, spacing) | One *artifact* a design system produces |
+| **Pattern library** | A catalogue of UI patterns (login form, empty state) | The "molecules/organisms" layer |
+| **Component library** | Shippable, importable code components | The "atoms/molecules" layer in code |
+| **UI kit** | Reusable design files (Figma library) | The Figma-side mirror of the component library |
+| **Brand guidelines** | Logo, voice, photography, identity rules | An *upstream* input the tokens encode |
+| **Design system** | All of the above + tokens + docs + governance + tooling | The umbrella |
+
+### The canonical anatomy
+
+A mature design system has six layers (this is the consensus stack across Material Design, Atlassian Design System, Shopify Polaris, IBM Carbon, Salesforce Lightning, and GitHub Primer):
+
+1. **Design tokens** — the indivisible, named values (`color.brand.500`, `space.4`, `radius.md`, `font.size.lg`). The W3C Design Tokens Community Group, whose specification reached its first stable version (2025.10) on October 28, 2025, defines a vendor-neutral JSON format with explicit support for theming, modern color spaces, and cross-tool interoperability. Salesforce coined the term "design tokens" in 2014.
+2. **Primitives / atoms** — typography, color, iconography, spacing, motion, elevation rules realized in code.
+3. **Components** — Button, Input, Dialog, Card, Toast. Accessible, themeable, composable.
+4. **Patterns / recipes** — repeatable UI compositions (e.g., a "post card with tag pills and timestamp"). Often the layer where Brad Frost's "organisms" live.
+5. **Documentation** — usage, do/don't, code examples, a11y notes, version history. Tools: Storybook, Zeroheight, Supernova, or a custom docs site.
+6. **Governance** — versioning policy, contribution workflow, deprecation strategy, ownership.
+
+### Well-known industry exemplars
+
+- **Material Design (Google)** — the most influential of all; its design tokens work directly informed the DTCG spec.
+- **Atlassian Design System** — strong on tokens-as-API and theming.
+- **Shopify Polaris** — exemplary docs and accessibility posture.
+- **IBM Carbon** — multi-platform (Web/iOS/Android/Native), Style-Dictionary-driven token pipeline.
+- **Salesforce Lightning** — birthplace of design tokens.
+- **GitHub Primer** — pragmatic; Primer Primitives package = pure tokens.
+- **Adobe Spectrum / React Spectrum (React Aria)** — gold standard for accessibility primitives.
+
+The throughline: tokens are the contract; components are the implementation; docs are the API; governance is the SLA.
+
+---
+
+## 2. What Makes a Design System *Good*?
+
+Below is a concrete evaluation rubric. Score 0–3 on each criterion; a healthy DS scores ≥2 on every row.
+
+| # | Criterion | What "good" looks like | What "bad" looks like |
+|---|---|---|---|
+| 1 | **Single source of truth** | Tokens defined once (DTCG JSON or Tailwind `@theme`), compiled to every consumer | Color hex codes duplicated across CSS, JS, Figma |
+| 2 | **Token architecture** | Three tiers: *primitive* (raw values) → *semantic* (`color.text.primary`) → *component* (`button.bg.hover`) | Flat list of 200 named colors with no aliasing |
+| 3 | **Theming / dark mode** | Theme = swap of semantic tokens; no component changes needed | Forked components per theme |
+| 4 | **Accessibility (a11y)** | WCAG 2.2 AA baseline, automated axe-core checks in CI, keyboard-tested, screen-reader-tested | Visual-only QA |
+| 5 | **Composability** | Components compose via slots, polymorphic `as`, or Radix-style `asChild` | Monolithic, prop-explosion components |
+| 6 | **Responsiveness** | Mobile-first; tested at common breakpoints | Desktop-only baselines |
+| 7 | **Performance** | Tree-shakable, CSS-variable-driven, low runtime cost (no heavy CSS-in-JS for static content) | Megabyte of JS to render a button |
+| 8 | **Documentation quality** | Each component has: purpose, anatomy, props, a11y notes, do/don't, code example | A README with three sentences |
+| 9 | **Developer experience** | One-command install (`shadcn add button`), type-safe APIs, autocomplete | Manual copying with broken imports |
+| 10 | **Versioning** | SemVer, changelog, deprecation warnings, migration codemods | Silent breaking changes |
+| 11 | **Design-dev handoff** | Tokens flow from Figma to code automatically (Tokens Studio, Figma MCP, Style Dictionary) | Eyeball-pixel-pushing in dev |
+| 12 | **Maintainability** | Tests + visual regression + a11y CI as quality gates | "It looked fine when I shipped it" |
+| 13 | **Adoption telemetry** | You know which components are used where | No insight into actual usage |
+| 14 | **LLM-readability** | Components live as plain source files; an `AGENTS.md` / `CLAUDE.md` explains conventions; an `llms.txt` indexes docs | Components hidden in opaque `node_modules` with no agent-readable docs |
+
+Criterion 14 is the new addition for 2025–2026. The shift to agent-driven development means a design system is now also evaluated on how legibly an LLM can read, reason about, and extend it — which is the central thesis of the next section.
+
+---
+
+## 3. Modern Building Blocks for an AI-Native Design System (with a Claude bias)
+
+The state of the practice in 2025–2026 is a *layered, code-owned* stack. Each layer has a clear winner; you should not mix and match outside this list unless you have a specific reason.
+
+### 3.1 The token layer
+
+- **W3C Design Tokens Community Group format** — JSON files with `$value`, `$type`, `$description`, and alias references (`{color.brand.500}`). Stable since the 2025.10 release on October 28, 2025. **Use it.** Filenames end in `.tokens.json`; media type is `application/design-tokens+json`. Per the DTCG announcement: "The new stable specification addresses [fragmentation] through standardized support for theming, modern color spaces, and cross-tool interoperability."
+- **Style Dictionary v4 (Amazon)** — the de facto tokens compiler; first-class DTCG support in v4. Per styledictionary.com/info/dtcg/: "As of version 4, Style Dictionary has first-class support for the DTCG format. Important note: the latest format 2025.10 does not have full support yet in Style Dictionary. This is a work in progress in v5."
+- **Tokens Studio** — Figma plugin that authors DTCG JSON; the canonical Figma↔code bridge.
+- **Tailwind CSS v4 `@theme` directive** — a *first-class* place to land your compiled tokens. In v4, `@theme { --color-primary-500: oklch(…); }` both registers a CSS variable and generates the corresponding utility (`bg-primary-500`). This collapses the old "tokens in JS config vs. CSS variables in `:root`" duplication into one source.
+
+### 3.2 The styling layer
+
+- **Tailwind CSS v4** is the dominant utility-first system in 2025–2026. Per Adam Wathan's release post on tailwindcss.com/blog/tailwindcss-v4 (January 22, 2025): "New high-performance engine — where full builds are up to 5x faster, and incremental builds are over 100x faster — and measured in microseconds." (Tailwind's own Catalyst benchmark cited "over 3.5x faster" full builds and "over 8x faster" incremental builds; the 5×/100× figures are stated maximums.) v4 also ships first-party Vite integration and exposes every theme value as a real CSS custom property. **CSS-in-JS (Emotion, styled-components) is no longer the default recommendation** for new projects — the React Server Components era favors zero-runtime CSS.
+- **CSS variables for theming**, always. Light/dark = swap `:root` vars or toggle a `.dark` class on `<html>`; no component edits needed.
+
+### 3.3 The primitives layer (unstyled, accessible behavior)
+
+Three serious contenders. Pick one:
+
+| Library | When to pick it |
+|---|---|
+| **Radix UI Primitives** | The default, ~30 components, used as the foundation for shadcn/ui. `@radix-ui/react-slot` records approximately 148 million weekly npm downloads as of May 15, 2026 (npmx.dev) — a useful proxy for shadcn/ui adoption. Radix was acquired by WorkOS; update cadence has slowed on some components. |
+| **Base UI** (formerly MUI Base) | The actively-maintained alternative, backed by the MUI team. shadcn/ui added Base UI as a supported primitive layer in 2025. |
+| **React Aria Components (Adobe)** | The deepest accessibility primitives; pick when WCAG compliance is a hard requirement (e.g., government). Heavier APIs, more code to write. |
+
+Pick **Radix** for a personal blog. It's the path of least resistance and the one shadcn/ui defaults to.
+
+### 3.4 The component model: shadcn/ui has won
+
+shadcn/ui is the dominant component system of 2025–2026 — not because it has the most components, but because of its distribution model. Per the official docs at ui.shadcn.com: "It is built around the following principles: **Open Code, Composition, Distribution, Beautiful Defaults, AI-Ready**." You run `npx shadcn add button` and the source code for `components/ui/button.tsx` lands in *your* repo. You own it. There is no `node_modules/shadcn-ui` to upgrade.
+
+Why this wins in an AI-native world:
+1. **Agents can read the code.** When you ask Claude to "make the dialog slide in from the right," it can open `components/ui/dialog.tsx`, see the actual classes, and modify them. With an opaque npm dependency, Claude has to guess at the theme object's shape.
+2. **No version lock-in.** The component is a checked-in `.tsx` (or `.jsx`) file. It changes when you change it.
+3. **It's a *registry*, not a library.** Per the official "August 2025 - shadcn CLI 3.0 and MCP Server" changelog at ui.shadcn.com/docs/changelog/2025-08-cli-3-mcp: "We just shipped shadcn CLI 3.0 with support for namespaced registries, advanced authentication, new commands and a completely rewritten registry engine." You can run your own private or public registry behind `@yourorg/component`.
+4. **MCP-native.** The shadcn MCP server (made zero-config in 2025) lets an AI agent browse a registry and install components by prompt rather than by typing CLI commands.
+
+The same changelog states: "Back in April, we introduced the first version of the MCP server. Since then, we've taken everything we learned and built a better MCP server… Works with all registries. Zero config." This is the unlock: a design system is now a thing an agent can *consume* as a tool, not just code an agent can edit.
+
+### 3.5 The MCP layer (the agentic glue)
+
+Three MCP servers matter for design systems in 2026:
+
+- **shadcn registry MCP** — your agent can call `get_items`, `add`, `init`, etc., against the official `ui.shadcn.com/r` registry or your own. Configure in `components.json`.
+- **Figma Dev Mode MCP** — Figma's remote MCP at `https://mcp.figma.com/mcp` (or local desktop server at `http://127.0.0.1:3845/mcp`). It exposes `get_design_context` (returns a React + Tailwind representation of the selection) and `get_variable_defs` (extracts colors, spacing, typography variables). For Claude Code, the recommended installer is `claude plugin install figma@claude-plugins-official`, per developers.figma.com/docs/figma-mcp-server/remote-server-installation/.
+- **Playwright MCP** — Microsoft's MCP server that drives a real browser. This is the visual-feedback loop: an agent navigates the dev server, takes a screenshot or DOM snapshot, evaluates against the design, and iterates. Kyle already uses this in his `CLAUDE.md` ("`mcp__playwright__browser_navigate` → `_take_screenshot` → `_snapshot` → `_close`").
+
+### 3.6 LLM-readable documentation: llms.txt, AGENTS.md, CLAUDE.md
+
+- **`/llms.txt`** — Jeremy Howard's proposal (llmstxt.org) for a Markdown file at site root that gives LLMs a curated map of the most important content. Adopted by Mintlify, Vercel, and others. Status: voluntary, treated as an "interesting idea" by most crawlers but increasingly useful for *your own* agents reading *your own* docs.
+- **`/llms-full.txt`** — a flattened, full-text dump of the most important docs (e.g., your design system reference), so an agent can ingest the entire spec in one fetch.
+- **`AGENTS.md`** — a joint open standard published by OpenAI, Google, Factory, Sourcegraph, and Cursor. Plain Markdown at the repo root. Per agents.md: "Think of AGENTS.md as a README for agents: a dedicated, predictable place to provide context and instructions to help AI coding agents work on your project." Compatible with Cursor, Codex, Aider, Gemini CLI, Jules, Zed, Phoenix, and others. The closest `AGENTS.md` to the file being edited wins.
+- **`CLAUDE.md`** — Claude Code's project memory file. Loaded at the start of every session; subdirectory `CLAUDE.md` files load when Claude reads files in that directory; `#`-prefixed lines in the REPL auto-append to memory. Kyle already maintains a 247-line root `CLAUDE.md`.
+
+The 2026 best practice is to use **Ruler** (or a similar tool) to author rules *once* and fan them out to `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/`, and `.opencode/agents/`. Kyle already has a `.ruler/` directory doing exactly this.
+
+### 3.7 Claude Code as the IDE for the design system
+
+The capabilities that matter for a design-system workflow:
+
+- **CLAUDE.md project memory** — already covered. Keep it under 250 lines; dense prose wastes context every session.
+- **Custom slash commands and skills** — `.claude/commands/*.md` (legacy) or `.claude/skills/<name>/SKILL.md` (new, recommended). The latter is loaded based on the `description` field, so well-written descriptions are how Claude discovers when to use them. Per the official Claude Code docs at code.claude.com/docs/en/slash-commands: "Every skill needs a SKILL.md file with two parts: YAML frontmatter (between --- markers) that tells Claude when to use the skill, and markdown content with instructions Claude follows when the skill is invoked." The `/goal` command (a session-level completion condition shipped in Claude Code v2.1.x) is purpose-built for "run until visual diff passes and a11y is clean" kinds of tasks.
+- **Subagents** — isolated Claude instances with their own context windows. Kyle has 11: Pai (orchestrator), Publisher, Analyst, Synthesizer, PRD Writer, Design Doc Writer, plus the auto-delegated Interviewee/Researcher/Reviewer/QA/Security Auditor.
+- **MCP integration** — `claude mcp add` registers servers; `/mcp` debugs them. The Figma plugin is installed via `claude plugin install figma@claude-plugins-official`.
+- **Hooks** — shell commands fired on lifecycle events (PostToolUse, PreCompact, etc.). Use these to auto-run `biome check` after edits, or `playwright test` after dependency upgrades.
+- **Artifacts** (Claude apps) — useful for quick component prototyping in chat; less relevant for the in-repo workflow.
+
+### 3.8 Visual & a11y guardrails for human-out-of-the-loop work
+
+The whole point of an agentic workflow is that the human doesn't have to look at every diff. That requires *machine-verifiable* quality signals. For a personal blog:
+
+- **Playwright `toHaveScreenshot()`** — built-in, free, zero new dependencies. The official Playwright docs (playwright.dev/docs/test-snapshots) describe layout-based diffing with configurable thresholds via `maxDiffPixels` and `maxDiffPixelRatio`; the standard guidance is to configure those thresholds and run snapshots in a containerized CI environment to eliminate environment-driven false positives (anti-aliasing, OS fonts, sub-pixel rendering).
+- **Playwright MCP** — drives the same browser from an agent prompt. Kyle is already using this.
+- **axe-core via `@axe-core/playwright`** — runs accessibility checks inside Playwright tests. Free, open source, the industry-standard a11y engine.
+- **Biome** for linting/formatting. Kyle uses Biome v2.0.0.
+- **Chromatic** — pay-for-it tier when you scale to many components and want a review UI. **Not warranted for a personal blog.**
+- **Storybook test runner** — only if you adopt Storybook. (You shouldn't, for this blog — see §4.)
+
+The agent feedback loop: *generate change → run Playwright + axe → diff snapshots → if pass, open PR; if fail, retry up to N times.* Kyle's existing `Reviewer` and `QA` subagents are already the right shape for this.
+
+---
+
+## 4. Prescriptive Guidance: A First-Class Design System for kyle.pericak.com
+
+### 4.1 What you actually have today (verified from the repo)
+
+This is the grounding for everything below. Confirmed from `apps/blog/README.md`, the root `CLAUDE.md`, and `biome.json`:
+
+- **Framework**: Next.js, **Pages Router** (`pages/[..route.js]`, `pages/_app.js`), **JavaScript** (not TypeScript).
+- **Styling**: **Material UI (MUI)** via `sx` props on page components; theme + `<head>` in `pages/_app.js`; small `styles/globals.css` for remark-rendered markdown HTML. Per `apps/blog/README.md`: "I've tried to keep the styles as close to the code as possible. Primarily in react's `sx` props on page components… Theme styles and `<head>` are in `pages/_app.js`."
+- **Content**: Plain `.md` files at `apps/blog/blog/markdown/posts/*.md`, parsed with **remark** (+ `remark-toc`, `remark-gfm`) and built to JSON; **Prism.js** for syntax highlighting.
+- **Build/deploy**: `bin/build-blog-files.sh` → static `out/` → Docker image `gcr.io/kylepericak/kylepericakdotcom` → Google Cloud Build reads `apps/blog/cloudbuild.yaml` → rsync to a public GCS bucket. Terraform-managed GCB trigger in `tf/`.
+- **Agentic tooling**: `CLAUDE.md` (247 lines), 11 Claude Code agents in `.claude/agents/` (Pai, Publisher, Analyst, Synthesizer, PRD Writer, Design Doc Writer + 5 subagents), `.ruler/` fans rules into `.cursor/rules/` and `.opencode/agents/`, `opencode.json`, `prompt-readme.md`.
+- **Quality gates**: Biome v2.0.0 (with blog-specific rule relaxations in `biome.json` for `<img>`, `dangerouslySetInnerHTML`, array index keys); pre-commit gitleaks via Docker; CodeRabbit (`chill` profile) with detailed per-path instructions — notably *"do not suggest grammar/tone changes"* for `apps/blog/blog/markdown/posts/**`; Playwright MCP for human-out-of-the-loop visual verification.
+
+**Implication**: you do not need to "rebuild" or even change frameworks. Next.js Pages Router with static export is a perfectly fine substrate for a ~100-post technical blog. You need to *layer in* a token system, a primitives layer, and a documentation surface — and gradually retire MUI from one component at a time as you go.
+
+### 4.2 The target stack (additive, mainstream, named)
+
+| Layer | Pick | Why this and not alternatives |
+|---|---|---|
+| Framework | **Keep Next.js Pages Router + JS** | The blog works. Migrating to App Router or TS is a separate project. |
+| Tokens (source) | **DTCG JSON in `apps/blog/design-system/tokens/`** | Open standard, future-proof, agent-readable. |
+| Tokens (compiler) | **Style Dictionary v4** | First-class DTCG; outputs CSS vars + JS module. |
+| Styling | **Tailwind CSS v4** alongside MUI | v4's `@theme` is the perfect landing pad for compiled DTCG tokens; CSS-variable-first matches dark-mode needs. |
+| Primitives | **Radix UI** | shadcn/ui default; battle-tested. |
+| Components | **shadcn/ui** (copy-paste, you own the code) | AI-native, no version churn, Claude can edit the files directly. |
+| Component CLI | **`shadcn` CLI 3.0+** | Adds components on demand; supports MCP. |
+| MCP — components | **shadcn MCP server** | Zero-config; Claude can install components by prompt. |
+| MCP — visuals | **Playwright MCP** (already in use) | Drives the verification loop. |
+| Docs surface | **A single `/design-system` Next.js route** + `apps/blog/design-system/AGENTS.md` + `/llms.txt` + `/llms-full.txt` | Sized for a solo blog. Not Storybook. |
+| Visual regression | **Playwright `toHaveScreenshot()`** + axe-core | Free, in-repo, agent-friendly. |
+| Author rules once | **Keep Ruler** | You already use it. |
+
+### 4.3 Should you adopt Storybook? No. Here's the reasoning.
+
+You have, realistically, ~8–12 components in a blog: Header/Nav, Footer, PostCard, PostList, PostLayout, Tag, Category, CodeBlock, Callout, TableOfContents, ArticleMeta, and a few markdown-element overrides (`h1`–`h6`, `a`, `img`). Storybook's value scales with: (a) team size, (b) component count, and (c) the need for public/shared documentation. For one author, ~12 components, and a private blog, Storybook adds:
+
+- A non-trivial install footprint. Per the official Storybook blog post *Storybook bloat? Fixed.* (storybook.js.org/blog/storybook-bloat-fixed, July 2025), pre-v9 installs routinely ran several hundred MB of `node_modules`; Storybook 9 cut install size by over 50% versus v8, and the ESM-only Storybook 10 cuts a further ~29%. The footprint argument has weakened, but the surface area is still meaningful.
+- A second build pipeline.
+- A maintenance tax (`@storybook/*` packages change frequently).
+- A second source of truth for "how this component looks in isolation."
+
+The *lighter alternative* that does 90% of what you need:
+
+> **A dedicated, unindexed `/design-system` Next.js route inside the blog itself.** Each component has a sub-route (`/design-system/post-card`, `/design-system/callout`) that renders it in a few canonical states. Add `<meta name="robots" content="noindex">` so it doesn't show in search. The agent navigates this route via Playwright MCP, screenshots it, and diffs. You read the source code instead of reading Storybook docs.
+
+Adopt Storybook *only* if and when you publish a component registry that other people consume, or open up the blog to multiple authors. Until then, the `/design-system` route is the right tool.
+
+### 4.4 Scope: what the design system should accomplish and own
+
+The design system is responsible for:
+
+**Tokens** (in `apps/blog/design-system/tokens/`):
+- `color.tokens.json` — primitive palette + semantic tokens (`color.text.primary`, `color.surface.elevated`, `color.code.bg`, etc.) + light/dark mode aliases.
+- `space.tokens.json` — 4px-based spacing scale (`0`, `1`, `2`, `3`, `4`, `6`, `8`, `12`, `16`, `24`, `32`, `48`, `64`).
+- `typography.tokens.json` — type scale (12 / 14 / 16 / 18 / 20 / 24 / 30 / 36 / 48), font families (mono for code, sans for body, optional serif for headings — Kyle's current MUI theme decides), line heights, letter spacing.
+- `radius.tokens.json`, `shadow.tokens.json`, `motion.tokens.json`, `breakpoint.tokens.json`.
+
+**Layout primitives** (in `apps/blog/design-system/primitives/`):
+- `<Container>` — max-width content well.
+- `<Stack>` and `<Cluster>` — vertical/horizontal flex with token-driven gap.
+- `<Grid>` — for archive/category pages.
+- `<Prose>` — wraps remark-rendered HTML; replaces MUI `<Typography>` for markdown content.
+
+**Blog components** (in `apps/blog/components/`, gradually copy-paste from `shadcn add`):
+- `<SiteHeader>` / `<SiteFooter>` / `<NavMenu>`.
+- `<PostCard>` (thumbnail + title + date + tags + excerpt — matches the homepage grid you already have).
+- `<PostLayout>` (article shell with title, meta, TOC, content, navigation).
+- `<CodeBlock>` (wraps Prism output; adds copy button, language label).
+- `<Callout>` (info / warn / tip / danger variants for blog posts).
+- `<TagPill>`, `<CategoryBadge>`, `<Breadcrumbs>`.
+- `<TableOfContents>` (sticky on desktop).
+- Markdown element overrides for `h1`–`h6`, `a`, `img`, `blockquote`, `table`.
+
+**Theming**:
+- Single `:root { --color-… }` set, swapped via `[data-theme="dark"]` on `<html>`. No JS theme provider needed; Tailwind v4's CSS variables do it natively.
+
+**Documentation**:
+- `/design-system` route (one page per component, with a "view source" link to the actual `.jsx` file).
+- `apps/blog/design-system/AGENTS.md` — how an agent should add, modify, or remove components.
+- `/llms.txt` and `/llms-full.txt` at the site root — so external coding agents (and your own Pai bot) can ingest the spec.
+
+**Governance**:
+- Solo author = lightweight. SemVer on the monorepo. A `CHANGELOG.md` in `apps/blog/design-system/`. A `/design-token` Claude Code slash command that enforces "no raw hex codes in components — only token references."
+
+### 4.5 How to interact with it: a Claude-Code-driven, mostly-human-out-of-the-loop workflow
+
+Add this section to your existing `.ruler/` source (which fans out to `CLAUDE.md`, `AGENTS.md`, `.cursor/rules/`):
+
+```markdown
+## Design system rules (apps/blog/design-system/)
+
+- All visual values come from `apps/blog/design-system/tokens/*.tokens.json` (DTCG format).
+- Never write raw hex, raw rem/px (except 0/1px), or raw shadow values in component code.
+- Components use Tailwind utility classes; classes resolve to token-backed CSS variables via `@theme`.
+- Markdown-rendered content lives inside a `<Prose>` primitive — do not nest <Typography> inside <Prose>.
+- When adding a new component:
+  1. Check `apps/blog/design-system/AGENTS.md` for naming and structure conventions.
+  2. Prefer `npx shadcn add <component>` over hand-rolling; review the generated file before commit.
+  3. Add a story page at `pages/design-system/<component>.js`.
+  4. Run `bin/verify-design-system.sh` (Playwright + axe + Biome).
+- When removing an MUI component:
+  1. Find all usages with `rg "@mui" apps/blog`.
+  2. Replace one file at a time; verify with the screenshot loop in CLAUDE.md.
+  3. Only remove the MUI dependency once `rg "@mui" apps/blog` returns nothing.
+```
+
+Add three Claude Code slash commands (skills) in `.claude/skills/`:
+
+1. **`/design-token`** — given a Figma frame URL or a description, the agent (a) calls Figma MCP's `get_variable_defs`, (b) maps to or adds DTCG tokens, (c) regenerates Tailwind theme via Style Dictionary, (d) opens a PR.
+2. **`/ds-add`** — given a component name, the agent (a) runs `npx shadcn add <name>`, (b) wires it to your tokens (replaces raw `bg-blue-500` with `bg-primary` etc.), (c) adds the story page, (d) runs `bin/verify-design-system.sh`, (e) opens a PR.
+3. **`/ds-replace-mui`** — given an MUI component name, the agent rewrites callers to use the shadcn equivalent, runs the screenshot loop, and opens a PR.
+
+Configure two Claude Code hooks in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      { "matcher": "Edit|Write", "hooks": [
+        { "type": "command", "command": "cd apps/blog && npx @biomejs/biome check --apply $CLAUDE_FILE_PATH || true" }
+      ]}
+    ]
+  }
+}
+```
+
+…and have `bin/verify-design-system.sh` do:
+
+```bash
+#!/usr/bin/env bash
+set -e
+cd apps/blog
+npx @biomejs/biome check .
+npx playwright test design-system/      # screenshots + axe assertions
+node scripts/check-no-raw-hex.mjs        # regex guard: no #abcdef in components/
+```
+
+This is the contract that lets Pai and Publisher work without you. The agent edits a component, the hook runs Biome on save, the verification script runs Playwright (which uses `toHaveScreenshot()` and `@axe-core/playwright`), and the PR either opens green or the agent retries.
+
+### 4.6 Phased implementation roadmap
+
+A realistic order of operations for working *with* Claude Code, one phase per session-ish.
+
+**Phase 0 — Inventory (1 session, mostly reading)**
+- Have Claude generate a component inventory: `find apps/blog/components -name '*.js' | xargs -I {} echo {}` and `rg "from '@mui" apps/blog --files-with-matches`.
+- Output: `apps/blog/design-system/INVENTORY.md` listing every existing component and every MUI usage.
+
+**Phase 1 — Stand up Tailwind v4 alongside MUI (1 session)**
+- Install `tailwindcss@4`, `@tailwindcss/postcss`, `@tailwindcss/typography`.
+- Add `apps/blog/styles/tailwind.css` with `@import "tailwindcss";` and an empty `@theme { }`.
+- Update PostCSS / Next.js config so Tailwind compiles. Keep MUI untouched; the two coexist.
+- Verify: nothing visible changes; build succeeds; bundle size diff documented.
+
+**Phase 2 — Token foundation (1 session)**
+- Create `apps/blog/design-system/tokens/{color,space,typography,radius,shadow,motion}.tokens.json` in DTCG format. Seed values by reading the current MUI theme in `pages/_app.js` and translating.
+- Install Style Dictionary v4. Add `apps/blog/design-system/sd.config.mjs` with a CSS-variables platform that writes into the `@theme` block of `tailwind.css`.
+- Add `npm run tokens` to `apps/blog/package.json`.
+- Commit the *generated* CSS so the build remains reproducible without running Style Dictionary.
+
+**Phase 3 — Stand up the `/design-system` route + AGENTS.md (1 session)**
+- Add `pages/design-system/index.js` with a noindex meta and a list of components.
+- Write `apps/blog/design-system/AGENTS.md` and `apps/blog/design-system/CLAUDE.md`.
+- Add `/llms.txt` and `/llms-full.txt` at the site root (point llms.txt at the design-system docs + the top 5 most-linked posts).
+
+**Phase 4 — First shadcn component (1 session)**
+- `npx shadcn init` in `apps/blog/`. Configure `components.json` to point at `components/ui/` and to use your token variables.
+- `npx shadcn add button` — your first owned component.
+- Convert one MUI `<Button>` call site as a pilot; verify visually with Playwright MCP.
+
+**Phase 5 — Replace MUI page-by-page (3–6 sessions)**
+- For each page in `pages/`: identify MUI usages, swap for shadcn/Radix equivalents, verify screenshots, open PR. Use the `/ds-replace-mui` slash command.
+- Components in priority order: `<Typography>` → `<Prose>` primitive; layout (`<Box>`, `<Container>`) → Tailwind utilities; navigation; `<Card>` → `<PostCard>`; tag chips → `<TagPill>`.
+
+**Phase 6 — Add the verification rails (1 session)**
+- Write `bin/verify-design-system.sh`.
+- Add `@axe-core/playwright`; write 3–5 Playwright tests that load `/design-system/*` and assert (a) `toHaveScreenshot()` matches, (b) axe finds zero serious/critical issues.
+- Add the PostToolUse Biome hook.
+- Add the `/design-token`, `/ds-add`, `/ds-replace-mui` skills.
+
+**Phase 7 — Wire the shadcn MCP server (1 session)**
+- `claude mcp add` for the shadcn MCP server (or `claude mcp add-json` with the official config).
+- Test by asking Claude in a session: "list available shadcn components" — it should answer via MCP, not by guessing.
+
+**Phase 8 — Optional: Figma Dev Mode MCP (only if you start designing in Figma)**
+- `claude plugin install figma@claude-plugins-official`.
+- This unlocks the `/design-token` flow from Figma frames. Skip if you don't use Figma.
+
+**Phase 9 — Remove MUI (1 session, last)**
+- `npm uninstall @mui/material @mui/icons-material @emotion/react @emotion/styled`.
+- Delete `theme.js` and the MUI theme provider from `_app.js`.
+- Final verification run.
+
+At the end you have: a token-driven, shadcn-based, agent-friendly design system that lives entirely in `apps/blog/`, with zero new fancy infrastructure beyond Tailwind v4 + Style Dictionary + a few `.skill` files.
+
+---
+
+## Recommendations (prioritized)
+
+1. **Start with Phase 1–2 this week.** Tailwind v4 alongside MUI + DTCG tokens via Style Dictionary is the highest-leverage move. Everything else flows from a real token source of truth.
+2. **Do not adopt Storybook.** Use the `/design-system` Next.js route. Revisit only if you publish a public registry or take on co-authors.
+3. **Write `apps/blog/design-system/AGENTS.md` before writing any component.** It's the agent's instruction manual. Mirror it from Ruler so `CLAUDE.md`, `.cursor/rules/`, and `AGENTS.md` stay aligned.
+4. **Make the verification script (`bin/verify-design-system.sh`) a hard gate** — Pai/Publisher PRs that fail it auto-close. This is what lets you stay out of the loop.
+5. **Use shadcn/ui with the Radix primitive layer, not React Aria.** React Aria is overkill for a blog; Radix is the path of least resistance and is what Claude has seen the most of in training.
+6. **Stay on JavaScript for now.** A TS migration is a separate project; don't conflate it with the design-system work. Reconsider once MUI is gone.
+
+**Benchmarks that should change the recommendations:**
+
+- If you start adding 30+ components or open up the blog as a multi-author publication, **adopt Storybook** — at that scale (and especially post-Storybook-9's slimmer install footprint) its docs/discovery value pays for the maintenance tax.
+- If you start collaborating with a designer in Figma, **wire up the Figma Dev Mode MCP** and adopt Tokens Studio as the upstream token authoring tool.
+- If a Playwright + axe loop ever exceeds ~30 components or you find yourself eyeballing diffs more than once a week, **upgrade to Chromatic** for its review UI.
+- If you ever want to publish your tokens or components for other developers/agents to consume, **publish a shadcn-compatible registry** (it's just a `registry.json` plus per-component JSON files at a public URL — the same `npx shadcn add @kylep/post-card` pattern shadcn CLI 3.0 enables).
+
+---
+
+## Caveats
+
+- **The design tokens spec is stable but young.** DTCG 2025.10 is the *first* stable version (October 28, 2025). Style Dictionary v4 has DTCG support but its own docs note that "the latest format 2025.10 does not have full support yet in Style Dictionary; this is a work in progress in v5." Expect minor breaking changes if you adopt bleeding-edge token features.
+- **shadcn/ui depends on you owning the maintenance.** The "no upgrade path" benefit is also the cost: if Radix ships a fix, you have to re-copy or hand-patch the component. For ~12 components this is fine; for 200 it is a serious tax.
+- **The `llms.txt` standard is voluntary.** Google, Anthropic, and OpenAI have not committed to honoring it as crawler instructions. Treat it as documentation for *your own* agents, not as an SEO/AEO lever.
+- **Visual regression is noisy.** Anti-aliasing, OS font rendering, and emoji differences can cause false-positive diffs across machines. Always run Playwright snapshots in a containerized CI environment (your existing Docker-based Cloud Build is a good substrate) and configure `maxDiffPixels` / `maxDiffPixelRatio` thresholds — strict pixel-perfect comparison without tolerance is widely cited as the leading cause of teams abandoning visual testing.
+- **MUI and Tailwind coexisting will temporarily inflate the bundle.** That's the cost of an additive migration. Phase 9 (uninstall MUI) recovers it.
+- **The Figma MCP requires a Dev or Full seat** on a paid Figma plan for sustained use; the Starter plan caps at 6 tool calls per month per the Figma MCP documentation. Skip it unless you actually use Figma.
+- **AGENTS.md and CLAUDE.md are not perfectly redundant.** Where they conflict, Claude Code prefers `CLAUDE.md`. Author once in Ruler; let Ruler resolve the precedence.
+- **The Storybook recommendation is intentionally contrarian.** Most "modern Next.js blog" guides recommend Storybook reflexively. For a solo blog the cost/benefit math doesn't work out, and Claude Code can read a `/design-system` route just as easily as it can read a Storybook docs page — arguably more easily, since it's just Next.js JSX.

--- a/apps/blog/blog/markdown/wiki/research/design-system/index.md
+++ b/apps/blog/blog/markdown/wiki/research/design-system/index.md
@@ -1,0 +1,65 @@
+---
+title: "A Modern, Agent-Native Design System for the Blog"
+summary: "Deep Research on building a modern, agent-native design system for kyle.pericak.com as a predicate to a blog redesign. Seed input for PER-135."
+keywords:
+  - deep-research
+  - design-system
+  - design-tokens
+  - tailwind
+  - storybook
+  - shadcn
+  - radix
+  - component-library
+  - blog-redesign
+related:
+  - wiki/research
+  - wiki/prds/blog-design-system
+  - wiki/design-docs/blog-design-system
+scope: "Subject index for design-system research. Currently a single-provider (Claude) report. Seed input for the PER-135 blog redesign."
+last_verified: 2026-06-13
+---
+
+Deep Research on what a modern, agent-native design system looks like
+and how to build one for kyle.pericak.com as a predicate to a blog
+redesign. Used as the seed input for the PER-135 design-system PRD and
+design doc.
+
+Unlike the other research subjects, this is currently a **single-provider**
+report (Claude only) rather than a cross-referenced three-provider set.
+
+## Prompt
+
+> Research a modern, agent-native design system for kyle.pericak.com as
+> a predicate to a blog redesign: what a design system is, what makes
+> one good, the modern building blocks (tokens, styling, primitives,
+> component model, MCP, LLM-readable docs), and prescriptive guidance
+> for an additive migration off the current Next.js Pages Router + MUI
+> stack.
+
+## Reports
+
+- [Claude Deep Research: Agent-Native Design System](/wiki/research/design-system/claude-report.html) —
+  6 sections: what a design system is, a 14-criterion quality rubric,
+  the modern building-block stack (DTCG tokens + Style Dictionary,
+  Tailwind v4, Radix primitives, the shadcn/ui copy-paste model, MCP
+  glue, llms.txt/AGENTS.md docs), and a prescriptive 10-phase additive
+  migration roadmap off MUI. Generated 2026-05-28.
+
+## How Kyle's steering diverges from the report
+
+The report is a **seed**, not a spec. For PER-135, Kyle's stated
+outcomes override several of its recommendations:
+
+- **Storybook is in scope** (the report recommends *against* it for a
+  solo blog). Kyle wants hands-on exposure and a demonstrable component
+  workshop.
+- **Tailwind is in scope** and wanted for exposure.
+- **Bias toward stable/mainstream** building blocks suitable for a
+  3–5+ year project — explicitly mitigating the report's own caveats
+  (young DTCG spec, shadcn self-maintenance, noisy visual regression).
+- The end state must be **demoable as a POC to other full-stack
+  experts** and **maintainable primarily through AI**.
+
+See [PER-135](https://linear.app/pericak/issue/PER-135/blog-redesign-agent-native-design-system),
+the [PRD](/wiki/prds/blog-design-system.html), and the
+[design doc](/wiki/design-docs/blog-design-system.html).

--- a/apps/blog/blog/markdown/wiki/research/index.md
+++ b/apps/blog/blog/markdown/wiki/research/index.md
@@ -49,3 +49,9 @@ used and links to the individual provider reports.
   Three reports on which Claude Code plugins, skills, and
   marketplaces are worth installing (file-level audit, token cost,
   trust surface, stack fit, ecosystem gaps). April 2026.
+- [Agent-Native Design System](/wiki/research/design-system.html) —
+  Single-provider (Claude) report on building a modern, agent-native
+  design system for the blog as a predicate to a redesign: design
+  tokens, Tailwind v4, Radix primitives, the shadcn/ui model, MCP
+  glue, and a phased additive migration off MUI. Seed input for the
+  PER-135 redesign. May 2026.


### PR DESCRIPTION
Planning artifacts for the blog redesign / design system ([PER-135](https://linear.app/pericak/issue/PER-135/blog-redesign-agent-native-design-system)). **Docs only — no app code yet.**

## What's here
- **Research migrated in:** the Claude Deep Research report *"A Modern, Agent-Native Design System for kyle.pericak.com"* (2026-05-28), now at `wiki/research/design-system/claude-report.md` with a subject index, registered in the research index.
- **PRD:** `wiki/prds/blog-design-system.md`
- **Design doc:** `wiki/design-docs/blog-design-system.md` (architecture, alternatives tables, file change list, dependency-ordered TASK breakdown for plan mode / autolearn).

## Grounded in the real repo, not the seed research
The seed research was stale. The PRD/design doc correct it: Next.js **15** Pages Router static export; **three** coexisting styling stacks (MUI 5 + Emotion real; **Tailwind v3 installed but inert**; styled-components dead weight); no design tokens; no dark mode; ESLint not Biome.

## Kyle's steering (overrides the research)
- **Storybook + Tailwind both in scope** (research recommended skipping Storybook).
- Bias to **stable/mainstream** building blocks for a 3–5yr horizon — mitigates the caveats Kyle disliked: Tailwind v4 `@theme` is the token source of truth (DTCG optional), Storybook+Playwright/axe for low-noise visual regression.
- A **demoable component library** (Radix + shadcn-seeded owned `.tsx`), **dark mode**, and a **verification gate** for mostly-autonomous execution.

## Open decisions for Kyle (in the docs)
Component model (shadcn-owned vs versioned lib), token format, visual direction (2–3 mockups proposed before mass work), React 18 vs 19, and whether to fan the tasks into `autolearn`-labeled Linear sub-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)