### PR TITLE
Add apps/ttrpg stub pointing to ky-ttrpg repo

### DIFF
--- a/apps/ttrpg/README.md
+++ b/apps/ttrpg/README.md
@@ -1,0 +1,9 @@
+# ttrpg
+
+This project lives in its own repo: [kylep/ky-ttrpg](https://github.com/kylep/ky-ttrpg).
+
+ky-ttrpg is an engine, scripts, and Claude Code skills for running tabletop
+RPGs, with Claude as game master. It needs its own repo because each game
+world is a separate private git repo instantiated from the engine's
+templates, and GM sessions launch Claude with a constrained agent/skillset
+independent of this monorepo's tooling.


### PR DESCRIPTION
# Description

Points the monorepo at the new home of the ttrpg project. The engine, design doc, and future skills live in [kylep/ky-ttrpg](https://github.com/kylep/ky-ttrpg) ([design doc](https://github.com/kylep/ky-ttrpg/blob/main/docs/design.md)); this stub keeps the project discoverable from `apps/`.

- **Problem/purpose of the change:** the ttrpg project moved to its own repo, leaving no trace of it in the monorepo.
- **What was changed:** added a stub README at `apps/ttrpg/` linking to ky-ttrpg and explaining why it lives separately.
- **Why this matters:** `apps/` stays the index of Kyle's active projects even when one lives out-of-repo.
- **Expected impact:** documentation only; no code or build impact.

# Files Changed

| File | Why it changed |
|------|----------------|
| `apps/ttrpg/README.md` | New stub pointing to the ky-ttrpg repo with a one-paragraph rationale. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the TTRPG project documentation to clarify that it is maintained in a separate repository.
  - Added an overview of the tabletop RPG engine, supporting scripts, and game-master experience.
  - Documented that individual game worlds use dedicated private repositories created from templates.
  - Clarified that game-master sessions operate independently from the current monorepo tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->