### PR TITLE
infra: pai-nuc single-node k3s bootstrap

### DIFF
--- a/apps/blog/blog/markdown/wiki/devops/index.md
+++ b/apps/blog/blog/markdown/wiki/devops/index.md
@@ -21,6 +21,7 @@ configuration management.
 - [Ruler](/wiki/devops/ruler.html) — Cross-tool AI rule inventory
 - [CodeRabbit](/wiki/devops/coderabbit.html) — False positive patterns and path_instructions
 - [AI Agents Infrastructure](/wiki/devops/ai-agents-infra.html) — Stack layout, ArgoCD GitOps, per-cluster config, bootstrap
+- [pai NUC k3s Cluster](/wiki/devops/pai-nuc-k3s.html) — Single-node k3s on the Intel NUC, SSH bootstrap, auto-deploy manifests
 - [Agent Controller](/wiki/devops/agent-controller.html) — K8s controller for autonomous AI agent runs via CRDs
 - [Bootstrap & Recovery](/wiki/devops/bootstrap.html) — Single-command bootstrap, Vault secrets, post-reboot recovery
 - [Mac Setup Learnings](/wiki/devops/mac-setup-learnings.html) — Gotchas from the Ansible Mac setup (playbook now in [multi-sandbox](https://github.com/kylep/multi-sandbox), unmaintained)

--- a/apps/blog/blog/markdown/wiki/devops/pai-nuc-k3s.md
+++ b/apps/blog/blog/markdown/wiki/devops/pai-nuc-k3s.md
@@ -1,0 +1,88 @@
+---
+title: "pai NUC k3s Cluster"
+summary: "Single-node k3s on the pai Intel NUC: Ubuntu 26.04 over WiFi, bootstrapped over SSH from infra/pai-nuc/, workloads via the k3s auto-deploy manifests dir."
+keywords:
+  - k3s
+  - kubernetes
+  - nuc
+  - homelab
+  - servicelb
+  - local-path
+  - ubuntu
+  - autoinstall
+  - bootstrap
+related:
+  - wiki/devops/ai-agents-infra
+  - wiki/devops/bootstrap
+scope: "Covers the pai NUC server setup, k3s install, networking, storage, and workload deployment. Does not cover the Mac clusters (pai-m1, kyle-m2) or the ai-agents stack."
+last_verified: 2026-07-17
+---
+
+Single-node Kubernetes homelab on an Intel NUC, hostname `pai`, at
+`192.168.2.240` on home WiFi. Everything about the machine is code in
+`infra/pai-nuc/`; the only manual steps were flashing USB sticks and
+pressing the power button.
+
+## The server
+
+- **Hardware**: Intel NUC, NVMe system disk, WiFi NIC (no ethernet run to it).
+- **OS**: Ubuntu Server 26.04 LTS, installed unattended via Ubuntu
+  autoinstall (cloud-init NoCloud: `user-data` on a `CIDATA` USB volume
+  answers every installer question — user, SSH key, disk layout, WiFi).
+  The autoinstall config holds the WiFi PSK and password hash, so it lives
+  in the private env-config repo, not here.
+- **Access**: `ssh pai` (key-only; password auth disabled). The `pai` user
+  has passwordless sudo. GitHub access is set up on the box: git-over-SSH
+  with its own ed25519 key plus an authenticated `gh` CLI.
+
+## The cluster
+
+k3s `v1.36.2+k3s1` (Kubernetes v1.36.2), installed by
+`infra/pai-nuc/bin/bootstrap.sh` over SSH with the version pinned. The
+server config is `infra/pai-nuc/k3s-config.yaml`, synced to
+`/etc/rancher/k3s/config.yaml` before install so no flags ride the
+curl-pipe.
+
+k3s defaults do the heavy lifting on a single node:
+
+- **Datastore**: sqlite (no etcd).
+- **Ingress/NAT**: bundled servicelb (klipper-lb) exposes any
+  `type: LoadBalancer` Service directly on the node's WiFi IP, with
+  kube-proxy NATing into the pod network. Bundled Traefik is also running
+  for HTTP ingress. No MetalLB — L2 announcement over WiFi is unreliable
+  and unnecessary with one node.
+- **Storage**: bundled local-path-provisioner backs PVCs with hostPath
+  volumes under `/var/lib/rancher/k3s/storage` (StorageClass
+  `local-path`, the default).
+
+## Workloads
+
+Manifests in `infra/pai-nuc/manifests/` are synced by the bootstrap script
+into `/var/lib/rancher/k3s/server/manifests/`, the k3s auto-deploy dir:
+k3s applies whatever lands there on startup and on file change. Removing a
+file does not delete its resources — delete those with kubectl.
+
+Current workloads:
+
+- `nginx.yaml` — generic nginx Deployment in the `web` namespace with a
+  LoadBalancer Service on port 8080: <http://pai:8080>.
+
+## Operating it
+
+```bash
+# from the Mac, in multi/
+infra/pai-nuc/bin/bootstrap.sh        # install/update k3s + sync manifests; idempotent
+infra/pai-nuc/bin/kubeconfig.sh       # write ~/.kube/pai-nuc.yaml
+export KUBECONFIG=~/.kube/pai-nuc.yaml
+kubectl get pods -A
+```
+
+On the box itself, `sudo k3s kubectl ...` always works. The k3s systemd
+unit (`k3s.service`) restarts the cluster on reboot with no extra steps.
+
+## Growing it later
+
+The ai-agents helmfile already supports per-cluster environments
+(`helmfile -e <env> apply`); adding a `pai-nuc` environment file is the
+path to running ArgoCD or agent workloads here. See
+[AI Agents Infra](/wiki/devops/ai-agents-infra.html).

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,7 +1,10 @@
 # Infrastructure
 
 Everything here runs on or supports the Rancher Desktop cluster on the
-Mac laptop.
+Mac laptop, except pai-nuc which is its own machine.
+
+## [pai-nuc](pai-nuc/)
+Single-node k3s on the pai Intel NUC (SSH bootstrap, auto-deploy manifests).
 
 ## [local-k8s](local-k8s/)
 Bootstrap for the local cluster (Vault etc.).

--- a/infra/pai-nuc/README.md
+++ b/infra/pai-nuc/README.md
@@ -1,0 +1,11 @@
+# pai-nuc
+
+Single-node k3s on the pai Intel NUC (Ubuntu Server 26.04, WiFi-attached at
+`pai` / 192.168.2.240).
+
+- `k3s-config.yaml` — the k3s server config, synced to `/etc/rancher/k3s/config.yaml`
+- `manifests/` — workloads, synced to the k3s auto-deploy dir
+- `bin/bootstrap.sh` — installs/updates everything over SSH; idempotent
+- `bin/kubeconfig.sh` — pulls a local kubeconfig to `~/.kube/pai-nuc.yaml`
+
+Full documentation: [pai NUC k3s wiki page](../../apps/blog/blog/markdown/wiki/devops/pai-nuc-k3s.md).

--- a/infra/pai-nuc/bin/bootstrap.sh
+++ b/infra/pai-nuc/bin/bootstrap.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Bootstrap k3s on the pai NUC from this Mac, over SSH.
+# Idempotent — safe to re-run; re-syncs config and manifests each time.
+#
+# Prereqs: `ssh pai` works passwordless (key + ~/.ssh/config alias) and the
+# pai user has passwordless sudo.
+
+K3S_VERSION="v1.36.2+k3s1"
+SSH_HOST="pai"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INFRA_DIR="$SCRIPT_DIR/.."
+
+echo "==> Syncing k3s config"
+scp -q "$INFRA_DIR/k3s-config.yaml" "$SSH_HOST:/tmp/k3s-config.yaml"
+ssh "$SSH_HOST" 'sudo mkdir -p /etc/rancher/k3s && sudo mv /tmp/k3s-config.yaml /etc/rancher/k3s/config.yaml'
+
+echo "==> Installing k3s $K3S_VERSION (no-op if already at this version)"
+ssh "$SSH_HOST" "curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=$K3S_VERSION sh -"
+
+echo "==> Syncing auto-deploy manifests"
+scp -q "$INFRA_DIR"/manifests/*.yaml "$SSH_HOST:/tmp/"
+for f in "$INFRA_DIR"/manifests/*.yaml; do
+  base="$(basename "$f")"
+  ssh "$SSH_HOST" "sudo mv /tmp/$base /var/lib/rancher/k3s/server/manifests/$base"
+done
+
+echo "==> Waiting for node Ready"
+ssh "$SSH_HOST" 'sudo k3s kubectl wait --for=condition=Ready node/pai --timeout=120s'
+
+echo "==> Done. Fetch a local kubeconfig with bin/kubeconfig.sh"

--- a/infra/pai-nuc/bin/kubeconfig.sh
+++ b/infra/pai-nuc/bin/kubeconfig.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Pull the pai NUC's kubeconfig to this Mac as a standalone file.
+# Usage: bin/kubeconfig.sh   then   export KUBECONFIG=~/.kube/pai-nuc.yaml
+
+SSH_HOST="pai"
+OUT="$HOME/.kube/pai-nuc.yaml"
+
+mkdir -p "$HOME/.kube"
+ssh "$SSH_HOST" 'cat /etc/rancher/k3s/k3s.yaml' \
+  | sed "s/127.0.0.1/$SSH_HOST/" \
+  | sed 's/: default/: pai-nuc/' \
+  > "$OUT"
+chmod 600 "$OUT"
+
+echo "Wrote $OUT"
+echo "Use it with:  export KUBECONFIG=$OUT"
+kubectl --kubeconfig "$OUT" get nodes

--- a/infra/pai-nuc/k3s-config.yaml
+++ b/infra/pai-nuc/k3s-config.yaml
@@ -1,0 +1,6 @@
+# k3s server config for the pai NUC → /etc/rancher/k3s/config.yaml
+# Every key is a k3s CLI flag with the leading dashes dropped.
+# Defaults are deliberate on a single node: sqlite datastore, and the
+# packaged coredns/traefik/servicelb/local-path/metrics-server addons.
+write-kubeconfig-mode: "0644"
+node-name: pai

--- a/infra/pai-nuc/manifests/nginx.yaml
+++ b/infra/pai-nuc/manifests/nginx.yaml
@@ -1,0 +1,50 @@
+# Generic nginx, reachable at http://pai:8080.
+# Deployed via the k3s auto-deploy dir (/var/lib/rancher/k3s/server/manifests):
+# k3s applies files there on startup and whenever they change.
+# servicelb (klipper-lb) binds the LoadBalancer port on the node's WiFi IP
+# and NATs into the pod network.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.29-alpine
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: web
+spec:
+  type: LoadBalancer
+  selector:
+    app: nginx
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 80

--- a/infra/pai-nuc/manifests/nginx.yaml
+++ b/infra/pai-nuc/manifests/nginx.yaml
@@ -26,6 +26,13 @@ spec:
       containers:
         - name: nginx
           image: nginx:1.29-alpine
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop: [ALL]
+              add: [CHOWN, SETUID, SETGID, NET_BIND_SERVICE]
           ports:
             - containerPort: 80
           resources:


### PR DESCRIPTION
Adds `infra/pai-nuc/`: full-IaC single-node k3s on the pai Intel NUC (Ubuntu 26.04, WiFi).

## What's here
- `k3s-config.yaml` — k3s server config, synced to `/etc/rancher/k3s/config.yaml` before install
- `bin/bootstrap.sh` — idempotent SSH bootstrap: pinned k3s v1.36.2+k3s1 install + manifest sync into the k3s auto-deploy dir
- `bin/kubeconfig.sh` — pulls `~/.kube/pai-nuc.yaml` to the Mac
- `manifests/nginx.yaml` — generic nginx, LoadBalancer :8080 via bundled servicelb
- Wiki page `wiki/devops/pai-nuc-k3s.md` documenting the server setup; devops index + infra README updated

## Verified
- Bootstrap ran clean against pai; node Ready on v1.36.2+k3s1
- `curl http://pai:8080` → HTTP 200 nginx welcome page (servicelb bound to 192.168.2.240)
- Survives reboot via the k3s systemd unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)